### PR TITLE
Extend automatic decode fields for structs

### DIFF
--- a/quote.go
+++ b/quote.go
@@ -1,22 +1,35 @@
 package dbr
 
 import (
-	"bytes"
+  "bytes"
 )
 
 // Quoter is the quoter to use for quoting text; use Mysql quoting by default
-var Quoter = MysqlQuoter{}
+var Quoter quoter = MysqlQuoter{}
 
 // Interface for driver-swappable quoting
 type quoter interface {
-	writeQuotedColumn()
+  writeQuotedColumn(column string, sql *bytes.Buffer)
 }
 
 // MysqlQuoter implements Mysql-specific quoting
 type MysqlQuoter struct{}
 
 func (q MysqlQuoter) writeQuotedColumn(column string, sql *bytes.Buffer) {
-	sql.WriteRune('`')
-	sql.WriteString(column)
-	sql.WriteRune('`')
+  sql.WriteRune('`')
+  sql.WriteString(column)
+  sql.WriteRune('`')
+}
+
+// PgQuoter implements Postgres-specific quoting
+type PgQuoter struct{}
+
+func (q PgQuoter) writeQuotedColumn(column string, sql *bytes.Buffer) {
+  sql.WriteRune('"')
+  sql.WriteString(column)
+  sql.WriteRune('"')
+}
+
+func SetQuoter(q quoter) {
+  Quoter = q
 }

--- a/struct_mapping.go
+++ b/struct_mapping.go
@@ -42,7 +42,11 @@ func (sess *Session) calculateFieldMap(recordType reflect.Type, columns []string
 					continue
 				}
 
-				name := fieldStruct.Tag.Get("db")
+				name := fieldStruct.Tag.Get("dbr")
+				if len(name) < 1 {
+					name = fieldStruct.Tag.Get("db")
+				}
+
 				if name != "-" {
 					if name == "" {
 						name = NameMapping(fieldStruct.Name)


### PR DESCRIPTION
add namespaces for related objects

```sql
select a.*, b.id as “relation__id”,  b.name as “relation__name” from a
INNER JOIN b ON a.sid = b.id
```

```go
type A struct {
  Id int64
  Rel *Rel `db:”relation”`
}

type Rel struct {
  Id int64
  Name string
}
```