### PR TITLE
Enhancement: Go test -short skips real database tests

### DIFF
--- a/delete_test.go
+++ b/delete_test.go
@@ -41,6 +41,10 @@ func TestDeleteTenStaringFromTwentyToSql(t *testing.T) {
 }
 
 func TestDeleteReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	// Insert a Barack

--- a/insert_test.go
+++ b/insert_test.go
@@ -63,6 +63,10 @@ func TestInsertRecordsToSql(t *testing.T) {
 }
 
 func TestInsertKeywordColumnName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	// Insert a column whose name is reserved
 	s := createRealSessionWithFixtures()
 	res, err := s.InsertInto("dbr_people").Columns("name", "key").Values("Barack", "44").Exec()
@@ -74,6 +78,10 @@ func TestInsertKeywordColumnName(t *testing.T) {
 }
 
 func TestInsertReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	// Insert by specifying values
 	s := createRealSessionWithFixtures()
 	res, err := s.InsertInto("dbr_people").Columns("name", "email").Values("Barack", "obama@whitehouse.gov").Exec()

--- a/insert_test.go
+++ b/insert_test.go
@@ -59,7 +59,7 @@ func TestInsertRecordsToSql(t *testing.T) {
 	sql, args := s.InsertInto("a").Columns("something_id", "user_id", "other").Record(objs[0]).Record(objs[1]).ToSql()
 
 	assert.Equal(t, sql, "INSERT INTO a (`something_id`,`user_id`,`other`) VALUES (?,?,?),(?,?,?)")
-	assert.Equal(t, args, []interface{}{1, 88, false, 2, 99, true})
+	assert.Equal(t, args, []interface{}{1, int64(88), false, 2, int64(99), true})
 }
 
 func TestInsertKeywordColumnName(t *testing.T) {

--- a/select_test.go
+++ b/select_test.go
@@ -220,6 +220,10 @@ func TestSelectVarieties(t *testing.T) {
 }
 
 func TestSelectLoadStructs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	var people []*dbrPerson
@@ -247,6 +251,10 @@ func TestSelectLoadStructs(t *testing.T) {
 }
 
 func TestSelectLoadStruct(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	// Found:
@@ -265,6 +273,10 @@ func TestSelectLoadStruct(t *testing.T) {
 }
 
 func TestSelectBySqlLoadStructs(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	var people []*dbrPerson
@@ -281,6 +293,10 @@ func TestSelectBySqlLoadStructs(t *testing.T) {
 }
 
 func TestSelectLoadValue(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	var name string
@@ -297,6 +313,10 @@ func TestSelectLoadValue(t *testing.T) {
 }
 
 func TestSelectLoadValues(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	var names []string
@@ -315,6 +335,10 @@ func TestSelectLoadValues(t *testing.T) {
 }
 
 func TestSelectReturn(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	name, err := s.Select("name").From("dbr_people").Where("email = 'jonathan@uservoice.com'").ReturnString()

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -8,6 +8,10 @@ import (
 )
 
 func TestTransactionReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	tx, err := s.Begin()
@@ -38,6 +42,10 @@ func TestTransactionReal(t *testing.T) {
 }
 
 func TestTransactionRollbackReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	// Insert by specifying values
 	s := createRealSessionWithFixtures()
 

--- a/types_test.go
+++ b/types_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestNullTypeScanning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	type nullTypeScanningTest struct {

--- a/update_test.go
+++ b/update_test.go
@@ -81,6 +81,10 @@ func TestUpdateTenStaringFromTwentyToSql(t *testing.T) {
 }
 
 func TestUpdateKeywordColumnName(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	// Insert a user with a key
@@ -105,6 +109,10 @@ func TestUpdateKeywordColumnName(t *testing.T) {
 }
 
 func TestUpdateReal(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping real database tests in short mode")
+	}
+
 	s := createRealSessionWithFixtures()
 
 	// Insert a George


### PR DESCRIPTION
I have a need to separate out integration tests which require a database connection.  A discussion of how integration tests should be handled:
http://stackoverflow.com/questions/25965584/separating-unit-tests-and-integration-tests-in-golang-testify

There are several ways to do this but I think using the short flag is probably the clearest.

This PR also includes a fix of "TestInsertRecordsToSql", which regressed at some point.