### PR TITLE
Make `camelCaseToSnakeCase` more robust.

### DIFF
--- a/util.go
+++ b/util.go
@@ -14,7 +14,9 @@ func camelCaseToSnakeCase(name string) string {
 
 	for i := 0; i < len(runes); i++ {
 		buf.WriteRune(unicode.ToLower(runes[i]))
-		if !unicode.IsUpper(runes[i]) && i != len(runes)-1 && unicode.IsUpper(runes[i+1]) {
+		if i != len(runes)-1 && unicode.IsUpper(runes[i+1]) &&
+			(unicode.IsLower(runes[i]) || unicode.IsDigit(runes[i]) ||
+				(i != len(runes)-2 && unicode.IsLower(runes[i+2]))) {
 			buf.WriteRune('_')
 		}
 	}

--- a/util_test.go
+++ b/util_test.go
@@ -41,6 +41,10 @@ func TestSnakeCase(t *testing.T) {
 			in:   "Float64Val",
 			want: "float64_val",
 		},
+		{
+			in:   "XMLName",
+			want: "xml_name",
+		},
 	} {
 		assert.Equal(t, test.want, camelCaseToSnakeCase(test.in))
 	}


### PR DESCRIPTION
Go's naming convention is not strictly CamelCase, as it prefers
acronyms in uppercase. It is `XMLName`, not `XmlName`.
The function `camelCaseToSnakeCase` needs to reflect that.