### PR TITLE
TWEAK: don't quote join table

### DIFF
--- a/join.go
+++ b/join.go
@@ -23,7 +23,8 @@ func Join(t JoinType, table interface{}, on interface{}) Builder {
 		buf.WriteString("JOIN ")
 		switch table := table.(type) {
 		case string:
-			buf.WriteString(d.QuoteIdent(table))
+			// FIXME: no quote ident
+			buf.WriteString(table)
 		default:
 			buf.WriteString(d.Placeholder())
 			buf.WriteValue(table)

--- a/select_test.go
+++ b/select_test.go
@@ -21,7 +21,7 @@ func TestSelectStmt(t *testing.T) {
 		Offset(4)
 	err := builder.Build(dialect.MySQL, buf)
 	assert.NoError(t, err)
-	assert.Equal(t, "SELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4", buf.String())
+	assert.Equal(t, "SELECT DISTINCT a, b FROM ? LEFT JOIN table2 ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4", buf.String())
 	// two functions cannot be compared
 	assert.Equal(t, 3, len(buf.Value()))
 }


### PR DESCRIPTION
To ensure it is quoted, use I("table").