### PR TITLE
FEATURE: Add insert ignore to API

### DIFF
--- a/insert.go
+++ b/insert.go
@@ -12,6 +12,7 @@ type InsertStmt struct {
 	Table  string
 	Column []string
 	Value  [][]interface{}
+	IgnoreDuplicates bool
 }
 
 // Build builds `INSERT INTO ...` in dialect
@@ -28,9 +29,13 @@ func (b *InsertStmt) Build(d Dialect, buf Buffer) error {
 		return ErrColumnNotSpecified
 	}
 
-	buf.WriteString("INSERT INTO ")
-	buf.WriteString(d.QuoteIdent(b.Table))
+	insertInto := "INSERT INTO "
+	if b.IgnoreDuplicates {
+		insertInto = "INSERT IGNORE INTO "
+	}
 
+	buf.WriteString(insertInto)
+	buf.WriteString(d.QuoteIdent(b.Table))
 	buf.WriteString(" (")
 
 	placeholder := new(bytes.Buffer)

--- a/insert_builder.go
+++ b/insert_builder.go
@@ -9,7 +9,6 @@ type InsertBuilder struct {
 	runner
 	EventReceiver
 	Dialect Dialect
-
 	RecordID reflect.Value
 
 	*InsertStmt
@@ -112,5 +111,10 @@ func (b *InsertBuilder) Record(structValue interface{}) *InsertBuilder {
 
 func (b *InsertBuilder) Values(value ...interface{}) *InsertBuilder {
 	b.InsertStmt.Values(value...)
+	return b
+}
+
+func (b *InsertBuilder) IgnoreDuplicateEntries() *InsertBuilder {
+	b.InsertStmt.IgnoreDuplicates = true
 	return b
 }


### PR DESCRIPTION
SQL offers INSERT IGNORE as a way to suppress duplicate insert errors; this PR adds this through an extension to the InsertBuilder.