### PR TITLE
TWEAK: don't use UTC in interpolation

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -135,7 +135,7 @@ func encodePlaceholder(value interface{}, d Dialect, w StringWriter) error {
 		return nil
 	case reflect.Struct:
 		if v.Type() == reflect.TypeOf(time.Time{}) {
-			w.WriteString(d.EncodeTime(v.Interface().(time.Time).UTC()))
+			w.WriteString(d.EncodeTime(v.Interface().(time.Time)))
 			return nil
 		}
 	case reflect.Slice:


### PR DESCRIPTION
Some dialects, for example, dialect.MySQL, will still convert time.Time
to UTC (2016-01-05).

This defers timezone conversion for dialects. One can create
app-specific dialect to maintain timezone info.
