### PR TITLE
Bug fix

### DIFF
--- a/union.go
+++ b/union.go
@@ -32,7 +32,9 @@ func (u *union) Build(d Dialect, buf Buffer) error {
 				buf.WriteString("ALL ")
 			}
 		}
+		buf.WriteString("(")
 		buf.WriteString(d.Placeholder())
+		buf.WriteString(")")
 		buf.WriteValue(b)
 	}
 	return nil


### PR DESCRIPTION
Select from an union all query should have a `()` around each placeholder, fix #47.