### PR TITLE
BUGFIX: go 1.6 changes

### DIFF
--- a/util.go
+++ b/util.go
@@ -48,7 +48,7 @@ func structValue(m map[string]reflect.Value, value reflect.Value) {
 		t := value.Type()
 		for i := 0; i < t.NumField(); i++ {
 			field := t.Field(i)
-			if field.PkgPath != "" {
+			if field.PkgPath != "" && !field.Anonymous {
 				// unexported
 				continue
 			}


### PR DESCRIPTION
The reflect package has resolved a long-standing incompatibility between the gc and gccgo toolchains regarding embedded unexported struct types containing exported fields. Code that walks data structures using reflection, especially to implement serialization in the spirit of the encoding/json and encoding/xml packages, may need to be updated.

The problem arises when using reflection to walk through an embedded unexported struct-typed field into an exported field of that struct. In this case, reflect had incorrectly reported the embedded field as exported, by returning an empty Field.PkgPath. Now it correctly reports the field as unexported but ignores that fact when evaluating access to exported fields contained within the struct.