### PR TITLE
Add UPSERT builder for mysql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+### Example user template template
+### Example user template
+
+# IntelliJ project files
+.idea
+*.iml
+out
+gen### OSX template
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+### Windows template
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk
+### Go template
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Created by .ignore support plugin (hsz.mobi)

--- a/expr.go
+++ b/expr.go
@@ -4,6 +4,8 @@ package dbr
 type raw struct {
 	Query string
 	Value []interface{}
+	UpsertValue map[string]interface{}
+
 }
 
 // Expr should be used when sql syntax is not supported

--- a/insert.go
+++ b/insert.go
@@ -9,9 +9,10 @@ import (
 type InsertStmt struct {
 	raw
 
-	Table  string
-	Column []string
-	Value  [][]interface{}
+	Table       string
+	Column      []string
+	Value       [][]interface{}
+	UpsertValue map[string]interface{}
 }
 
 // Build builds `INSERT INTO ...` in dialect
@@ -57,6 +58,23 @@ func (b *InsertStmt) Build(d Dialect, buf Buffer) error {
 		buf.WriteValue(tuple...)
 	}
 
+	if len(b.UpsertValue) > 0 {
+		buf.WriteString(" ON DUPLICATE KEY UPDATE ")
+
+		i := 0
+		for col, v := range b.UpsertValue {
+			if i > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(d.QuoteIdent(col))
+			buf.WriteString(" = ")
+			buf.WriteString(d.Placeholder())
+
+			buf.WriteValue(v)
+			i++
+		}
+	}
+
 	return nil
 }
 
@@ -64,6 +82,8 @@ func (b *InsertStmt) Build(d Dialect, buf Buffer) error {
 func InsertInto(table string) *InsertStmt {
 	return &InsertStmt{
 		Table: table,
+		UpsertValue: make(map[string]interface{}),
+
 	}
 }
 
@@ -73,6 +93,7 @@ func InsertBySql(query string, value ...interface{}) *InsertStmt {
 		raw: raw{
 			Query: query,
 			Value: value,
+			UpsertValue: make(map[string]interface{}),
 		},
 	}
 }
@@ -104,6 +125,20 @@ func (b *InsertStmt) Record(structValue interface{}) *InsertStmt {
 			}
 		}
 		b.Values(value...)
+	}
+	return b
+}
+
+func (b *InsertStmt) Set(column string, value interface{}) *InsertStmt {
+
+	b.UpsertValue[column] = value
+	return b
+}
+
+// SetMap specifies a list of key-value pair
+func (b *InsertStmt) OnDuplicateKeyUpdate(m map[string]interface{}) *InsertStmt {
+	for col, val := range m {
+		b.Set(col, val)
 	}
 	return b
 }

--- a/insert_builder.go
+++ b/insert_builder.go
@@ -114,3 +114,8 @@ func (b *InsertBuilder) Values(value ...interface{}) *InsertBuilder {
 	b.InsertStmt.Values(value...)
 	return b
 }
+
+func (b *InsertBuilder) OnDuplicateKeyUpdate(m map[string]interface{}) *InsertBuilder {
+	b.InsertStmt.OnDuplicateKeyUpdate(m)
+	return b
+}

--- a/insert_test.go
+++ b/insert_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/gocraft/dbr/dialect"
 	"github.com/stretchr/testify/assert"
-	"fmt"
 )
 
 type insertTest struct {
@@ -28,7 +27,6 @@ func TestInsertStmt(t *testing.T) {
 func TestUpsertStmt(t *testing.T) {
 
 	setMap := map[string]interface{}{"b": "three"}
-	fmt.Println(setMap)
 
 	buf := NewBuffer()
 	builder := InsertInto("table").Columns("a", "b").Values(1, "one").Record(&insertTest{


### PR DESCRIPTION
Add feature "INSERT ON DUPLICATE KEY UPDATE" for MySQL.

``` go
setMap := map[string]interface{}{"b": "three"}
builder := InsertInto("table").Columns("a", "b").Values(1, "one").Record(&insertTest{
    A: 2,
    C: "two",
}).OnDuplicateKeyUpdate(setMap)
```
