### PR TITLE
increase time precision up to microseconds

### DIFF
--- a/dialect/dialect.go
+++ b/dialect/dialect.go
@@ -10,7 +10,7 @@ var (
 )
 
 const (
-	timeFormat = "2006-01-02 15:04:05"
+	timeFormat = "2006-01-02 15:04:05.000000"
 )
 
 func quoteIdent(s, quote string) string {

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -37,8 +37,8 @@ func TestInterpolateForDialect(t *testing.T) {
 		},
 		{
 			query: "?",
-			value: []interface{}{time.Date(2008, 9, 17, 20, 4, 26, 0, time.UTC)},
-			want:  "'2008-09-17 20:04:26'",
+			value: []interface{}{time.Date(2008, 9, 17, 20, 4, 26, 123456000, time.UTC)},
+			want:  "'2008-09-17 20:04:26.123456'",
 		},
 		{
 			query: "?",

--- a/now.go
+++ b/now.go
@@ -9,7 +9,7 @@ type nowSentinel struct{}
 
 // Now is a value that serializes to the current time
 var Now = nowSentinel{}
-var timeFormat = "2006-01-02 15:04:05"
+var timeFormat = "2006-01-02 15:04:05.000000"
 
 // Value implements a valuer for compatibility
 func (n nowSentinel) Value() (driver.Value, error) {


### PR DESCRIPTION
MySQL 5.7 has fractional seconds support for TIME, DATETIME, and TIMESTAMP values, with up to microseconds (6 digits) precision. 
Some other SQL db also support fractional seconds. 
