### PR TITLE
fix accessing camel cased field names in Load

### DIFF
--- a/load.go
+++ b/load.go
@@ -66,6 +66,7 @@ func findPtr(column []string, value reflect.Value) ([]interface{}, error) {
 		var ptr []interface{}
 		m := structMap(value)
 		for _, key := range column {
+			key = camelCaseToSnakeCase(key)
 			if val, ok := m[key]; ok {
 				ptr = append(ptr, val.Addr().Interface())
 			} else {


### PR DESCRIPTION
Load was not behaving properly with camel cased field names without db tags: the tags were renamed from camel to snake case in [structValue](https://github.com/gocraft/dbr/blob/master/util.go#L62), but when findPtr [looked for a value in the resulting struct](https://github.com/gocraft/dbr/blob/master/load.go#L69), it did not do the same conversion.

An example struct where Load was failing:
```type Foo struct {
	FooBar       string `json:"FooBar"`
	BarFoo      string `json:"BarFoo"`
}```