### PR TITLE
FEATURE: add struct support to UpdateStmt.Set

### DIFF
--- a/update.go
+++ b/update.go
@@ -1,5 +1,9 @@
 package dbr
 
+import (
+	"reflect"
+)
+
 // UpdateStmt builds `UPDATE ...`
 type UpdateStmt struct {
 	raw
@@ -83,7 +87,17 @@ func (b *UpdateStmt) Where(query interface{}, value ...interface{}) *UpdateStmt 
 
 // Set specifies a key-value pair
 func (b *UpdateStmt) Set(column string, value interface{}) *UpdateStmt {
-	b.Value[column] = value
+	v := reflect.ValueOf(value)
+	if v.Kind() == reflect.Ptr && !v.IsNil() {
+		v = v.Elem()
+	}
+	if v.Kind() == reflect.Struct {
+		m := structMap(v)
+		b.Value[column] = m[column].Interface()
+	} else {
+		b.Value[column] = value
+	}
+
 	return b
 }
 


### PR DESCRIPTION
`Set()` now supports a struct as value, much like `Load()` does.

Example:

```go
type User struct {
	ID         int64
	Firstname  string
	Lastname   string
	FacebookID dbr.NullString `db:"fb_id"`
	GoogleID   dbr.NullString `db:"gp_id"`
}

socialField := "gp_id"
stmt := sess.Update("user").Set(socialField, user).Where("id = ?", user.ID)
```

You could even do:
```go
stmt := sess.Update("user").Where("id = ?", user.ID)
fields := []string{"firstname", "lastname", "fb_id"}
for field := range fields {
	stmt.Set(field, user)
}
stmt.Exec()
```