### PR TITLE
Implement an automatic management of nilable fields based on field tag

### DIFF
--- a/condition_test.go
+++ b/condition_test.go
@@ -3,7 +3,7 @@ package dbr
 import (
 	"testing"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/dbr.go
+++ b/dbr.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 )
 
 // Open instantiates a Connection for a given database/sql connection

--- a/dbr_test.go
+++ b/dbr_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	_ "github.com/go-sql-driver/mysql"
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/stretchr/testify/assert"

--- a/delete_test.go
+++ b/delete_test.go
@@ -3,7 +3,7 @@ package dbr
 import (
 	"testing"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/insert_test.go
+++ b/insert_test.go
@@ -3,7 +3,7 @@ package dbr
 import (
 	"testing"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/select_test.go
+++ b/select_test.go
@@ -3,7 +3,7 @@ package dbr
 import (
 	"testing"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/types_test.go
+++ b/types_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/update_test.go
+++ b/update_test.go
@@ -3,7 +3,7 @@ package dbr
 import (
 	"testing"
 
-	"github.com/gocraft/dbr/dialect"
+	"github.com/skilld-labs/dbr/dialect"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util.go
+++ b/util.go
@@ -34,8 +34,8 @@ var (
 	typeValuer = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 )
 
-var nilablesIndex map[int]bool
-var nilables = map[string]reflect.Type {
+var nilablesIndex = make(map[int]bool)
+var nilables = map[string]reflect.Type{
 	"uint":      reflect.TypeOf(*new(NullInt64)),
 	"uint8":     reflect.TypeOf(*new(NullInt64)),
 	"uint16":    reflect.TypeOf(*new(NullInt64)),
@@ -89,8 +89,8 @@ func structValue(m map[string]reflect.Value, value reflect.Value) {
 			if _, ok := m[tag]; !ok {
 				_, supportedNilable := nilables[field.Type.String()]
 				if nilable && supportedNilable {
-						m[tag] = reflect.New(nilables[field.Type.String()]).Elem()
-						nilablesIndex[len(m) - 1] = true
+					m[tag] = reflect.New(nilables[field.Type.String()]).Elem()
+					nilablesIndex[len(m)-1] = true
 				} else {
 					m[tag] = fieldValue
 				}


### PR DESCRIPTION
This change allow to stop using Null* types directly, by using instead a field tag : `db:"!"`
Doing so allow us to pass the loaded structures to other layers of our application without having those ones to know anything about database access layer (in other words: decoupling the structures from database).

For instance one could use :

```
// columns are mapped by tag then by field
type Suggestion struct {
	ID int64  // id, will be autoloaded by last insert id
	Title string // title
	Url string `db:"-"` // ignored
	secret string // ignored
	Body string `db:"!"` // implicit null string type (dbr.NullString)
	User User
}

// By default dbr converts CamelCase property names to snake_case column_names
// You can override this with struct tags, just like with JSON tags
// This is especially helpful while migrating from legacy systems
type Suggestion struct {
	Id        int64
	Title     string `db:"!"` // implicit null string type (dbr.NullString)
	CreatedAt time.Time `db:"!"` // implicit null time type (dbr.NullTime)
}

var suggestions []Suggestion
sess.Select("*").From("suggestions").Load(&suggestions)
```