### PR TITLE
Fix handling of null for int64s and add a test

### DIFF
--- a/types.go
+++ b/types.go
@@ -99,6 +99,10 @@ func (n *NullString) UnmarshalJSON(b []byte) error {
 
 // UnmarshalJSON correctly deserializes a NullInt64 from JSON
 func (n *NullInt64) UnmarshalJSON(b []byte) error {
+	if bytes.Equal(b, nullString) {
+		return n.Scan(nil)
+	}
+
 	var s json.Number
 	if err := json.Unmarshal(b, &s); err != nil {
 		return err

--- a/types_test.go
+++ b/types_test.go
@@ -101,3 +101,21 @@ func TestNullTypesJSON(t *testing.T) {
 		assert.Equal(t, test.in, test.out)
 	}
 }
+
+func TestNullTypesActuallyNullJSON(t *testing.T) {
+	var out struct {
+		Bool   NullBool    `json:"b"`
+		Float  NullFloat64 `json:"f"`
+		String NullString  `json:"s"`
+		Time   NullTime    `json:"t"`
+		Int    NullInt64   `json:"i"`
+	}
+	jsonBs := []byte(`{"b":null,"f":null,"s":null,"t":null,"i":null}`)
+	err := json.Unmarshal(jsonBs, &out)
+	assert.NoError(t, err)
+	assert.False(t, out.Bool.Valid)
+	assert.False(t, out.Float.Valid)
+	assert.False(t, out.String.Valid)
+	assert.False(t, out.Time.Valid)
+	assert.False(t, out.Int.Valid)
+}


### PR DESCRIPTION
Commit 6125e71 introduced a bug where NullInt64 no longer unmarshalled nulls as it unmarshals to a json.Number which is just an alias for string and therefore can't be null.