### PR TITLE
custom types who are slices and implement sql.Scanner interface

### DIFF
--- a/load.go
+++ b/load.go
@@ -19,7 +19,8 @@ func Load(rows *sql.Rows, value interface{}) (int, error) {
 		return 0, ErrInvalidPointer
 	}
 	v = v.Elem()
-	isSlice := v.Kind() == reflect.Slice && v.Type().Elem().Kind() != reflect.Uint8
+	isScanner := v.Addr().Type().Implements(typeScanner)
+	isSlice := v.Kind() == reflect.Slice && v.Type().Elem().Kind() != reflect.Uint8 && !isScanner
 	count := 0
 	for rows.Next() {
 		var elem reflect.Value


### PR DESCRIPTION
This fixes issue #113

Custom types who are slices and implement the sql.scanner interface are treated as slices instead of sql.Scanner. And therefore the scan method is not invoked upon data retrieval from database 