### PR TITLE
We don't want the escaped doubled placeholder on the final query

### DIFF
--- a/interpolate.go
+++ b/interpolate.go
@@ -56,7 +56,7 @@ func (i *interpolator) interpolate(query string, value []interface{}, topLevel b
 
 		// escape placeholder by repeating it twice
 		if strings.HasPrefix(query[index:], escapedPlaceholder) {
-			i.WriteString(query[:index+len(escapedPlaceholder)])
+			i.WriteString(query[:index+1]) // Write placeholder once, not twice
 			query = query[index+len(escapedPlaceholder):]
 			continue
 		}

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -139,12 +139,12 @@ func TestInterpolateForDialect(t *testing.T) {
 		{
 			query: "???? ? ?? ? ??",
 			value: []interface{}{1, 2},
-			want:  "???? 1 ?? 2 ??",
+			want:  "?? 1 ? 2 ?",
 		},
 		{
 			query: "???",
 			value: []interface{}{1},
-			want:  "??1",
+			want:  "?1",
 		},
 	} {
 		s, err := InterpolateForDialect(test.query, test.value, dialect.MySQL)


### PR DESCRIPTION
This properly fixes #106, otherwise we get a pq error due to a help token in the final query. Is there any case were we would want the double escaped placeholder on the final query?