### PR TITLE
Add `Rows` and `RowsContext` methods to SelectStmt

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -141,7 +141,7 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 	return result, nil
 }
 
-func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect) (*sql.Rows, error) {
+func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect) (string, *sql.Rows, error) {
 	timeout := runner.GetTimeout()
 	if timeout > 0 {
 		var cancel func()
@@ -157,7 +157,7 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 	err := i.encodePlaceholder(builder, true)
 	query, value := i.String(), i.Value()
 	if err != nil {
-		return nil, log.EventErrKv("dbr.select.interpolate", err, kvs{
+		return query, nil, log.EventErrKv("dbr.select.interpolate", err, kvs{
 			"sql":  query,
 			"args": fmt.Sprint(value),
 		})
@@ -172,50 +172,16 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 
 	rows, err := runner.QueryContext(ctx, query, value...)
 	if err != nil {
-		return nil, log.EventErrKv("dbr.select.load.query", err, kvs{
+		return query, nil, log.EventErrKv("dbr.select.load.query", err, kvs{
 			"sql": query,
 		})
 	}
 
-	return rows, nil
+	return query, rows, nil
 }
 
 func query(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect, dest interface{}) (int, error) {
-	timeout := runner.GetTimeout()
-	if timeout > 0 {
-		var cancel func()
-		ctx, cancel = context.WithTimeout(ctx, timeout)
-		defer cancel()
-	}
-
-	i := interpolator{
-		Buffer:       NewBuffer(),
-		Dialect:      d,
-		IgnoreBinary: true,
-	}
-	err := i.encodePlaceholder(builder, true)
-	query, value := i.String(), i.Value()
-	if err != nil {
-		return 0, log.EventErrKv("dbr.select.interpolate", err, kvs{
-			"sql":  query,
-			"args": fmt.Sprint(value),
-		})
-	}
-
-	startTime := time.Now()
-	defer func() {
-		log.TimingKv("dbr.select", time.Since(startTime).Nanoseconds(), kvs{
-			"sql": query,
-		})
-	}()
-
-	rows, err := runner.QueryContext(ctx, query, value...)
-	if err != nil {
-		return 0, log.EventErrKv("dbr.select.load.query", err, kvs{
-			"sql": query,
-		})
-	}
-
+	query, rows, dest := queryRows(ctx, runner, log, builder, d)
 	count, err := Load(rows, dest)
 	if err != nil {
 		return 0, log.EventErrKv("dbr.select.load.scan", err, kvs{

--- a/dbr.go
+++ b/dbr.go
@@ -141,6 +141,45 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 	return result, nil
 }
 
+func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect) (*sql.Rows, error) {
+	timeout := runner.GetTimeout()
+	if timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+
+	i := interpolator{
+		Buffer:       NewBuffer(),
+		Dialect:      d,
+		IgnoreBinary: true,
+	}
+	err := i.encodePlaceholder(builder, true)
+	query, value := i.String(), i.Value()
+	if err != nil {
+		return nil, log.EventErrKv("dbr.select.interpolate", err, kvs{
+			"sql":  query,
+			"args": fmt.Sprint(value),
+		})
+	}
+
+	startTime := time.Now()
+	defer func() {
+		log.TimingKv("dbr.select", time.Since(startTime).Nanoseconds(), kvs{
+			"sql": query,
+		})
+	}()
+
+	rows, err := runner.QueryContext(ctx, query, value...)
+	if err != nil {
+		return nil, log.EventErrKv("dbr.select.load.query", err, kvs{
+			"sql": query,
+		})
+	}
+
+	return rows, nil
+}
+
 func query(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect, dest interface{}) (int, error) {
 	timeout := runner.GetTimeout()
 	if timeout > 0 {
@@ -176,6 +215,7 @@ func query(ctx context.Context, runner runner, log EventReceiver, builder Builde
 			"sql": query,
 		})
 	}
+
 	count, err := Load(rows, dest)
 	if err != nil {
 		return 0, log.EventErrKv("dbr.select.load.scan", err, kvs{

--- a/select.go
+++ b/select.go
@@ -2,6 +2,7 @@ package dbr
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 )
 
@@ -316,6 +317,15 @@ func (b *SelectStmt) FullJoin(table, on interface{}) *SelectStmt {
 // As creates alias for select statement.
 func (b *SelectStmt) As(alias string) Builder {
 	return as(b, alias)
+}
+
+// Rows executes the query and returns the rows returned, or any error encountered.
+func (b *SelectStmt) Rows() (*sql.Rows, error) {
+	return b.RowsContext(context.Background())
+}
+
+func (b *SelectStmt) RowsContext(ctx context.Context) (*sql.Rows, error) {
+	return queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
 }
 
 func (b *SelectStmt) LoadOneContext(ctx context.Context, value interface{}) error {

--- a/select.go
+++ b/select.go
@@ -325,7 +325,8 @@ func (b *SelectStmt) Rows() (*sql.Rows, error) {
 }
 
 func (b *SelectStmt) RowsContext(ctx context.Context) (*sql.Rows, error) {
-	return queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	_, rows, err := queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	return rows, err
 }
 
 func (b *SelectStmt) LoadOneContext(ctx context.Context, value interface{}) error {

--- a/select_test.go
+++ b/select_test.go
@@ -117,6 +117,38 @@ func TestMaps(t *testing.T) {
 	}
 }
 
+func TestSelectRows(t *testing.T) {
+	for _, sess := range testSession {
+		reset(t, sess)
+
+		_, err := sess.InsertInto("dbr_people").
+			Columns("name", "email").
+			Values("test1", "test1@test.com").
+			Values("test2", "test2@test.com").
+			Values("test3", "test3@test.com").
+			Exec()
+
+		rows, err := sess.Select("*").From("dbr_people").Rows()
+		require.NoError(t, err)
+
+		want := []dbrPerson{
+			{Id: 1, Name: "test1", Email: "test1@test.com"},
+			{Id: 2, Name: "test2", Email: "test2@test.com"},
+			{Id: 3, Name: "test3", Email: "test3@test.com"},
+		}
+
+		count := 0
+		for rows.Next() {
+			var p dbrPerson
+			require.NoError(t, rows.Scan(&p.Id, &p.Name, &p.Email))
+			require.Equal(t, want[count], p)
+			count++
+		}
+
+		require.Equal(t, 3, len(want))
+	}
+}
+
 func TestInterfaceLoader(t *testing.T) {
 	for _, sess := range testSession {
 		reset(t, sess)

--- a/select_test.go
+++ b/select_test.go
@@ -145,7 +145,7 @@ func TestSelectRows(t *testing.T) {
 			count++
 		}
 
-		require.Equal(t, 3, len(want))
+		require.Equal(t, len(want), count)
 	}
 }
 


### PR DESCRIPTION
I'm adding dbr to some legacy code right now, and until I have time to refactor some of the code to handle things differently, I've found myself wanting to build the query with dbr but process the rows differently. These are entirely convenience methods that allow fetching rows from a SelectStmt. They do not change any of the internals of dbr.