### PR TITLE
Add Like and NotLike condition builders

### DIFF
--- a/condition.go
+++ b/condition.go
@@ -1,6 +1,8 @@
 package dbr
 
-import "reflect"
+import (
+	"reflect"
+)
 
 func buildCond(d Dialect, buf Buffer, pred string, cond ...Builder) error {
 	for i, c := range cond {
@@ -115,5 +117,34 @@ func Lt(column string, value interface{}) Builder {
 func Lte(column string, value interface{}) Builder {
 	return BuildFunc(func(d Dialect, buf Buffer) error {
 		return buildCmp(d, buf, "<=", column, value)
+	})
+}
+
+func buildLike(d Dialect, buf Buffer, column, pattern string, isNot bool, escape []string) error {
+	buf.WriteString(d.QuoteIdent(column))
+	if isNot {
+		buf.WriteString(" NOT LIKE ")
+	} else {
+		buf.WriteString(" LIKE ")
+	}
+	buf.WriteString(d.EncodeString(pattern))
+	if len(escape) > 0 {
+		buf.WriteString(" ESCAPE ")
+		buf.WriteString(d.EncodeString(escape[0]))
+	}
+	return nil
+}
+
+// Like is `LIKE`, with an optional `ESCAPE` clause
+func Like(column, value string, escape ...string) Builder {
+	return BuildFunc(func(d Dialect, buf Buffer) error {
+		return buildLike(d, buf, column, value, false, escape)
+	})
+}
+
+// NotLike is `NOT LIKE`, with an optional `ESCAPE` clause
+func NotLike(column, value string, escape ...string) Builder {
+	return BuildFunc(func(d Dialect, buf Buffer) error {
+		return buildLike(d, buf, column, value, true, escape)
 	})
 }

--- a/condition_test.go
+++ b/condition_test.go
@@ -63,6 +63,36 @@ func TestCondition(t *testing.T) {
 			query: "(`a` < ?) AND ((`b` > ?) OR (`c` != ?))",
 			value: []interface{}{1, 2, 3},
 		},
+		{
+			cond:  Like("a", "%BLAH%", "#"),
+			query: "`a` LIKE '%BLAH%' ESCAPE '#'",
+			value: nil,
+		},
+		{
+			cond:  Like("a", "%50#%%", "#"),
+			query: "`a` LIKE '%50#%%' ESCAPE '#'",
+			value: nil,
+		},
+		{
+			cond:  NotLike("a", "%BLAH%", "#"),
+			query: "`a` NOT LIKE '%BLAH%' ESCAPE '#'",
+			value: nil,
+		},
+		{
+			cond:  NotLike("a", "%50#%%", "#"),
+			query: "`a` NOT LIKE '%50#%%' ESCAPE '#'",
+			value: nil,
+		},
+		{
+			cond:  Like("a", "_x_"),
+			query: "`a` LIKE '_x_'",
+			value: nil,
+		},
+		{
+			cond:  NotLike("a", "_x_"),
+			query: "`a` NOT LIKE '_x_'",
+			value: nil,
+		},
 	} {
 		buf := NewBuffer()
 		err := test.cond.Build(dialect.MySQL, buf)


### PR DESCRIPTION
There's currently another PR with similar purpose open, but in my opinion it adds a lot of complexity that is unnecessary for such a lightweight feature. I have added Like and NotLike methods to the top-level namespace, both of which accept an optional `ESCAPE` parameter. In case you're skeptical (I was, as I had not used this before and assumed it went at the end of a condition), Postgres, MySQL, and Microsoft SQL all support the `ESCAPE` keyword, and it can be used inside a condition such as the following:
```sql
# matches movies whose name starts with '50%' and were released after 2000
SELECT * FROM `movies` WHERE `title` LIKE "50#%%" ESCAPE "#" and `release_year` > 2000 
```
(view on sqlfiddle: http://sqlfiddle.com/#!9/74b26e/1/0)