### PR TITLE
add OpenTracing query span instrumentation

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -136,6 +136,7 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 	}()
 	span, ctx := ot.StartSpanFromContext(ctx, "dbr.exec")
 	otext.DBStatement.Set(span, query)
+	otext.DBType.Set(span, "sql")
 	defer span.Finish()
 
 	result, err := runner.ExecContext(ctx, query, value...)
@@ -175,6 +176,7 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 	}()
 	span, ctx := ot.StartSpanFromContext(ctx, "dbr.select")
 	otext.DBStatement.Set(span, query)
+	otext.DBType.Set(span, "sql")
 	defer span.Finish()
 
 	rows, err := runner.QueryContext(ctx, query, value...)


### PR DESCRIPTION
Would you accept a patch to add OpenTracing spans? Unfortunately the existing EventReceiver interface doesn't pass the context.Context through, so this seemed like the cleanest way to add tracing for DBR queries. Let me know what you think.

This relies on the user to call `opentracing.SetGlobalTracer` before making dbr queries. If no global tracer is set, the OpenTracing Go library does nothing — the [NoopTracer](https://godoc.org/github.com/opentracing/opentracing-go#NoopTracer) is used, which performs no actions and is implemented using empty structs to prevent allocation overhead.