### PR TITLE
refactor opentracing into optional interface

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -132,16 +132,16 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 		})
 	}()
 
-	otimpl, hasOpenTracing := log.(TracingEventReceiver)
-	if hasOpenTracing {
-		ctx = otimpl.SpanStart(ctx, "dbr.exec", query)
-		defer otimpl.SpanFinish(ctx)
+	traceImpl, hasTracingImpl := log.(TracingEventReceiver)
+	if hasTracingImpl {
+		ctx = traceImpl.SpanStart(ctx, "dbr.exec", query)
+		defer traceImpl.SpanFinish(ctx)
 	}
 
 	result, err := runner.ExecContext(ctx, query, value...)
 	if err != nil {
-		if hasOpenTracing {
-			otimpl.SpanError(ctx, err)
+		if hasTracingImpl {
+			traceImpl.SpanError(ctx, err)
 		}
 		return result, log.EventErrKv("dbr.exec.exec", err, kvs{
 			"sql": query,
@@ -175,16 +175,16 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 		})
 	}()
 
-	otimpl, hasOpenTracing := log.(TracingEventReceiver)
-	if hasOpenTracing {
-		ctx = otimpl.SpanStart(ctx, "dbr.select", query)
-		defer otimpl.SpanFinish(ctx)
+	traceImpl, hasTracingImpl := log.(TracingEventReceiver)
+	if hasTracingImpl {
+		ctx = traceImpl.SpanStart(ctx, "dbr.select", query)
+		defer traceImpl.SpanFinish(ctx)
 	}
 
 	rows, err := runner.QueryContext(ctx, query, value...)
 	if err != nil {
-		if hasOpenTracing {
-			otimpl.SpanError(ctx, err)
+		if hasTracingImpl {
+			traceImpl.SpanError(ctx, err)
 		}
 		return query, nil, log.EventErrKv("dbr.select.load.query", err, kvs{
 			"sql": query,

--- a/dbr.go
+++ b/dbr.go
@@ -132,7 +132,7 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 		})
 	}()
 
-	otimpl, hasOpenTracing := log.(OpenTracingEventReceiver)
+	otimpl, hasOpenTracing := log.(TracingEventReceiver)
 	if hasOpenTracing {
 		ctx = otimpl.SpanStart(ctx, "dbr.exec", query)
 		defer otimpl.SpanFinish(ctx)
@@ -175,7 +175,7 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 		})
 	}()
 
-	otimpl, hasOpenTracing := log.(OpenTracingEventReceiver)
+	otimpl, hasOpenTracing := log.(TracingEventReceiver)
 	if hasOpenTracing {
 		ctx = otimpl.SpanStart(ctx, "dbr.select", query)
 		defer otimpl.SpanFinish(ctx)

--- a/event.go
+++ b/event.go
@@ -12,9 +12,9 @@ type EventReceiver interface {
 	TimingKv(eventName string, nanoseconds int64, kvs map[string]string)
 }
 
-// OpenTracingEventReceiver is an optional interface an EventReceiver type can implement
-// to allow opentracing instrumentation
-type OpenTracingEventReceiver interface {
+// TracingEventReceiver is an optional interface an EventReceiver type can implement
+// to allow tracing instrumentation
+type TracingEventReceiver interface {
 	EventReceiver
 
 	SpanStart(ctx context.Context, eventName, query string) context.Context

--- a/event.go
+++ b/event.go
@@ -15,8 +15,6 @@ type EventReceiver interface {
 // TracingEventReceiver is an optional interface an EventReceiver type can implement
 // to allow tracing instrumentation
 type TracingEventReceiver interface {
-	EventReceiver
-
 	SpanStart(ctx context.Context, eventName, query string) context.Context
 	SpanError(ctx context.Context, err error)
 	SpanFinish(ctx context.Context)

--- a/event.go
+++ b/event.go
@@ -1,5 +1,7 @@
 package dbr
 
+import "context"
+
 // EventReceiver gets events from dbr methods for logging purposes.
 type EventReceiver interface {
 	Event(eventName string)
@@ -8,6 +10,16 @@ type EventReceiver interface {
 	EventErrKv(eventName string, err error, kvs map[string]string) error
 	Timing(eventName string, nanoseconds int64)
 	TimingKv(eventName string, nanoseconds int64, kvs map[string]string)
+}
+
+// OpenTracingEventReceiver is an optional interface an EventReceiver type can implement
+// to allow opentracing instrumentation
+type OpenTracingEventReceiver interface {
+	EventReceiver
+
+	SpanStart(ctx context.Context, eventName, query string) context.Context
+	SpanError(ctx context.Context, err error)
+	SpanFinish(ctx context.Context)
 }
 
 type kvs map[string]string

--- a/opentracing/event_receiver.go
+++ b/opentracing/event_receiver.go
@@ -8,8 +8,10 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
+// EventReceiver implements dbr.TracingEventReceiver for opentracing-go
 type EventReceiver struct{}
 
+// SpanStart starts a new query span from ctx, then returns a new context with the new span.
 func (EventReceiver) SpanStart(ctx context.Context, eventName, query string) context.Context {
 	span, ctx := ot.StartSpanFromContext(ctx, eventName)
 	otext.DBStatement.Set(span, query)
@@ -17,12 +19,14 @@ func (EventReceiver) SpanStart(ctx context.Context, eventName, query string) con
 	return ctx
 }
 
+// SpanFinish finishes the span associated with ctx.
 func (EventReceiver) SpanFinish(ctx context.Context) {
 	if span := ot.SpanFromContext(ctx); span != nil {
 		span.Finish()
 	}
 }
 
+// SpanError adds an error to the span associated with ctx.
 func (EventReceiver) SpanError(ctx context.Context, err error) {
 	if span := ot.SpanFromContext(ctx); span != nil {
 		otext.Error.Set(span, true)

--- a/opentracing/event_receiver.go
+++ b/opentracing/event_receiver.go
@@ -1,0 +1,31 @@
+package opentracing
+
+import (
+	"context"
+
+	ot "github.com/opentracing/opentracing-go"
+	otext "github.com/opentracing/opentracing-go/ext"
+	otlog "github.com/opentracing/opentracing-go/log"
+)
+
+type EventReceiver struct{}
+
+func (EventReceiver) SpanStart(ctx context.Context, eventName, query string) context.Context {
+	span, ctx := ot.StartSpanFromContext(ctx, eventName)
+	otext.DBStatement.Set(span, query)
+	otext.DBType.Set(span, "sql")
+	return ctx
+}
+
+func (EventReceiver) SpanFinish(ctx context.Context) {
+	if span := ot.SpanFromContext(ctx); span != nil {
+		span.Finish()
+	}
+}
+
+func (EventReceiver) SpanError(ctx context.Context, err error) {
+	if span := ot.SpanFromContext(ctx); span != nil {
+		otext.Error.Set(span, true)
+		span.LogFields(otlog.String("event", "error"), otlog.Error(err))
+	}
+}

--- a/opentracing/event_receiver.go
+++ b/opentracing/event_receiver.go
@@ -8,7 +8,8 @@ import (
 	otlog "github.com/opentracing/opentracing-go/log"
 )
 
-// EventReceiver implements dbr.TracingEventReceiver for opentracing-go
+// EventReceiver provides an embeddable implementation of dbr.TracingEventReceiver
+// powered by opentracing-go.
 type EventReceiver struct{}
 
 // SpanStart starts a new query span from ctx, then returns a new context with the new span.


### PR DESCRIPTION
Refactored opentracing support into an optional interface so that dbr doesn't have to import opentracing directly.

There is also an embeddable implementation of this optional interface in `dbr/opentracing`. I can remove this (or put it in the readme as an example) if you'd rather not have a subpackage for it.

I suspect changes will be needed before this can be merged.
I'll be happy to modify as requested 🙂 

RE: #152 