### PR TITLE
Fix ability to pass TracingEventReceiver to dbr

### DIFF
--- a/dbr_test.go
+++ b/dbr_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gocraft/dbr/dialect"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -89,6 +88,7 @@ func reset(t *testing.T, sess *Session) {
 		_, err := sess.Exec(v)
 		require.NoError(t, err)
 	}
+	// clear test data collected by testTraceReceiver
 	sess.EventReceiver = &testTraceReceiver{}
 }
 
@@ -176,19 +176,19 @@ func TestTimeout(t *testing.T) {
 		var people []dbrPerson
 		_, err := sess.Select("*").From("dbr_people").Load(&people)
 		require.Equal(t, context.DeadlineExceeded, err)
-		assert.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
 
 		_, err = sess.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
 		require.Equal(t, context.DeadlineExceeded, err)
-		assert.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
 
 		_, err = sess.Update("dbr_people").Set("name", "test1").Exec()
 		require.Equal(t, context.DeadlineExceeded, err)
-		assert.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
 
 		_, err = sess.DeleteFrom("dbr_people").Exec()
 		require.Equal(t, context.DeadlineExceeded, err)
-		assert.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
 
 		// tx op timeout
 		sess.Timeout = 0

--- a/delete.go
+++ b/delete.go
@@ -59,7 +59,7 @@ func DeleteFrom(table string) *DeleteStmt {
 func (sess *Session) DeleteFrom(table string) *DeleteStmt {
 	b := DeleteFrom(table)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -68,7 +68,7 @@ func (sess *Session) DeleteFrom(table string) *DeleteStmt {
 func (tx *Tx) DeleteFrom(table string) *DeleteStmt {
 	b := DeleteFrom(table)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }
@@ -88,7 +88,7 @@ func DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 func (sess *Session) DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 	b := DeleteBySql(query, value...)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -97,7 +97,7 @@ func (sess *Session) DeleteBySql(query string, value ...interface{}) *DeleteStmt
 func (tx *Tx) DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 	b := DeleteBySql(query, value...)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }

--- a/event_test.go
+++ b/event_test.go
@@ -1,0 +1,18 @@
+package dbr
+
+import (
+	"context"
+)
+
+type testTraceReceiver struct {
+	NullEventReceiver
+	started           []struct{ eventName, query string }
+	errored, finished int
+}
+
+func (t *testTraceReceiver) SpanStart(ctx context.Context, eventName, query string) context.Context {
+	t.started = append(t.started, struct{ eventName, query string }{eventName, query})
+	return ctx
+}
+func (t *testTraceReceiver) SpanError(ctx context.Context, err error) { t.errored++ }
+func (t *testTraceReceiver) SpanFinish(ctx context.Context)           { t.finished++ }

--- a/insert.go
+++ b/insert.go
@@ -88,7 +88,7 @@ func InsertInto(table string) *InsertStmt {
 func (sess *Session) InsertInto(table string) *InsertStmt {
 	b := InsertInto(table)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -97,7 +97,7 @@ func (sess *Session) InsertInto(table string) *InsertStmt {
 func (tx *Tx) InsertInto(table string) *InsertStmt {
 	b := InsertInto(table)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }
@@ -116,7 +116,7 @@ func InsertBySql(query string, value ...interface{}) *InsertStmt {
 func (sess *Session) InsertBySql(query string, value ...interface{}) *InsertStmt {
 	b := InsertBySql(query, value...)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -125,7 +125,7 @@ func (sess *Session) InsertBySql(query string, value ...interface{}) *InsertStmt
 func (tx *Tx) InsertBySql(query string, value ...interface{}) *InsertStmt {
 	b := InsertBySql(query, value...)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/gocraft/dbr/dialect"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -35,12 +34,12 @@ func TestPostgresReturning(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, person.Id > 0)
 	require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
-	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.select")
-	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
-	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
-	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
-	assert.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
-	assert.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
+	require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.select")
+	require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
+	require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
+	require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
+	require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
+	require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
 }
 
 func BenchmarkInsertValuesSQL(b *testing.B) {

--- a/insert_test.go
+++ b/insert_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gocraft/dbr/dialect"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,6 +34,13 @@ func TestPostgresReturning(t *testing.T) {
 		Returning("id").Load(&person.Id)
 	require.NoError(t, err)
 	require.True(t, person.Id > 0)
+	require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
+	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.select")
+	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
+	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
+	assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
+	assert.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
+	assert.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
 }
 
 func BenchmarkInsertValuesSQL(b *testing.B) {

--- a/select.go
+++ b/select.go
@@ -155,7 +155,7 @@ func prepareSelect(a []string) []interface{} {
 func (sess *Session) Select(column ...string) *SelectStmt {
 	b := Select(prepareSelect(column)...)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -164,7 +164,7 @@ func (sess *Session) Select(column ...string) *SelectStmt {
 func (tx *Tx) Select(column ...string) *SelectStmt {
 	b := Select(prepareSelect(column)...)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }
@@ -185,7 +185,7 @@ func SelectBySql(query string, value ...interface{}) *SelectStmt {
 func (sess *Session) SelectBySql(query string, value ...interface{}) *SelectStmt {
 	b := SelectBySql(query, value...)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -194,7 +194,7 @@ func (sess *Session) SelectBySql(query string, value ...interface{}) *SelectStmt
 func (tx *Tx) SelectBySql(query string, value ...interface{}) *SelectStmt {
 	b := SelectBySql(query, value...)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }

--- a/transaction.go
+++ b/transaction.go
@@ -28,7 +28,7 @@ func (sess *Session) BeginTx(ctx context.Context, opts *sql.TxOptions) (*Tx, err
 	sess.Event("dbr.begin")
 
 	return &Tx{
-		EventReceiver: sess,
+		EventReceiver: sess.EventReceiver,
 		Dialect:       sess.Dialect,
 		Tx:            tx,
 		Timeout:       sess.GetTimeout(),

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -3,7 +3,6 @@ package dbr
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,12 +19,12 @@ func TestTransactionCommit(t *testing.T) {
 		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
 		require.NoError(t, err)
 		require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
-		assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.exec")
-		assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
-		assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
-		assert.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
-		assert.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
-		assert.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.exec")
+		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
+		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
+		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
+		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
+		require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
 
 		rowsAffected, err := result.RowsAffected()
 		require.NoError(t, err)
@@ -37,7 +36,7 @@ func TestTransactionCommit(t *testing.T) {
 		var person dbrPerson
 		err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
 		require.Error(t, err)
-		assert.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
 	}
 }
 

--- a/update.go
+++ b/update.go
@@ -81,7 +81,7 @@ func Update(table string) *UpdateStmt {
 func (sess *Session) Update(table string) *UpdateStmt {
 	b := Update(table)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -90,7 +90,7 @@ func (sess *Session) Update(table string) *UpdateStmt {
 func (tx *Tx) Update(table string) *UpdateStmt {
 	b := Update(table)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }
@@ -111,7 +111,7 @@ func UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 func (sess *Session) UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 	b := UpdateBySql(query, value...)
 	b.runner = sess
-	b.EventReceiver = sess
+	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
 }
@@ -120,7 +120,7 @@ func (sess *Session) UpdateBySql(query string, value ...interface{}) *UpdateStmt
 func (tx *Tx) UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 	b := UpdateBySql(query, value...)
 	b.runner = tx
-	b.EventReceiver = tx
+	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
 }


### PR DESCRIPTION
After trying out #153 I discovered it doesn't work — this is because composition is used to add `EventReceiver` to various structs, and so it loses track of the original EventReceiver implementation when passing it around, and then the type assertion for `TracingEventReceiver` in dbr.go does not work. This adds some failing test cases asserting that tracing works, then fixes them.

A bigger change would be to name the `EventReceiver` rather than using an anonymous embedding, but I didn't want to make such a big change.