### PR TITLE
Prevent unneeded parentheses around UNION

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -74,7 +74,7 @@ func ExampleSelectStmt_Join() {
 func ExampleSelectStmt_As() {
 	sess := mysqlSession
 	sess.Select("count(id)").From(
-		Select("*").From("suggestions").As("count"),
+		Select(I("IDX").As("id")).From("suggestions"),
 	)
 }
 
@@ -151,12 +151,12 @@ func ExampleUnion() {
 	Union(
 		Select("*"),
 		Select("*"),
-	).As("subquery")
+	)
 }
 
 func ExampleUnionAll() {
 	UnionAll(
 		Select("*"),
 		Select("*"),
-	).As("subquery")
+	)
 }

--- a/interpolate.go
+++ b/interpolate.go
@@ -103,7 +103,7 @@ func (i *interpolator) encodePlaceholder(value interface{}, topLevel bool) error
 		}
 		paren := false
 		switch value.(type) {
-		case *SelectStmt, *union:
+		case *SelectStmt:
 			paren = !topLevel
 		}
 		if paren {

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -113,8 +113,8 @@ func TestInterpolateForDialect(t *testing.T) {
 		},
 		{
 			query: "?",
-			value: []interface{}{Select("a").From("table").As("a1")},
-			want:  "(SELECT a FROM table) AS `a1`",
+			value: []interface{}{Select(I("a").As("A")).From("table")},
+			want:  "SELECT `a` AS `A` FROM table",
 		},
 		{
 			query: "?",
@@ -122,9 +122,9 @@ func TestInterpolateForDialect(t *testing.T) {
 				UnionAll(
 					Select("a").From("table1"),
 					Select("b").From("table2"),
-				).As("t"),
+				),
 			},
-			want: "((SELECT a FROM table1) UNION ALL (SELECT b FROM table2)) AS `t`",
+			want: "(SELECT a FROM table1) UNION ALL (SELECT b FROM table2)",
 		},
 		{
 			query: "?",

--- a/select.go
+++ b/select.go
@@ -314,11 +314,6 @@ func (b *SelectStmt) FullJoin(table, on interface{}) *SelectStmt {
 	return b
 }
 
-// As creates alias for select statement.
-func (b *SelectStmt) As(alias string) Builder {
-	return as(b, alias)
-}
-
 // Rows executes the query and returns the rows returned, or any error encountered.
 func (b *SelectStmt) Rows() (*sql.Rows, error) {
 	return b.RowsContext(context.Background())

--- a/union.go
+++ b/union.go
@@ -6,20 +6,14 @@ type union struct {
 }
 
 // Union builds `... UNION ...`.
-func Union(builder ...Builder) interface {
-	Builder
-	As(string) Builder
-} {
+func Union(builder ...Builder) Builder {
 	return &union{
 		builder: builder,
 	}
 }
 
 // UnionAll builds `... UNION ALL ...`.
-func UnionAll(builder ...Builder) interface {
-	Builder
-	As(string) Builder
-} {
+func UnionAll(builder ...Builder) Builder {
 	return &union{
 		builder: builder,
 		all:     true,
@@ -38,8 +32,4 @@ func (u *union) Build(d Dialect, buf Buffer) error {
 		buf.WriteValue(b)
 	}
 	return nil
-}
-
-func (u *union) As(alias string) Builder {
-	return as(u, alias)
 }


### PR DESCRIPTION
- Remove *union from parens check in interpolate.go
- Remove SelectStmt.As and Union.As
- Fix Issue #167