### PR TITLE
Fix parentheses for UNION and SELECT...AS

### DIFF
--- a/dbr_test.go
+++ b/dbr_test.go
@@ -39,7 +39,10 @@ var (
 	sqlite3Session        = createSession("sqlite3", sqlite3DSN)
 
 	// all test sessions should be here
-	testSession = []*Session{mysqlSession, postgresSession, sqlite3Session}
+	testSession = []struct {
+		Sess *Session
+		Test string
+	}{{Test: "mysql", Sess: mysqlSession}, {Test: "postgres", Sess: postgresSession}, {Test: "sqlite3", Sess: sqlite3Session}}
 )
 
 type dbrPerson struct {
@@ -93,120 +96,119 @@ func reset(t *testing.T, sess *Session) {
 }
 
 func TestBasicCRUD(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		jonathan := dbrPerson{
-			Name:  "jonathan",
-			Email: "jonathan@uservoice.com",
-		}
-		insertColumns := []string{"name", "email"}
-		if sess.Dialect == dialect.PostgreSQL {
-			jonathan.Id = 1
-			insertColumns = []string{"id", "name", "email"}
-		}
-		// insert
-		result, err := sess.InsertInto("dbr_people").Columns(insertColumns...).Record(&jonathan).Exec()
-		require.NoError(t, err)
+			jonathan := dbrPerson{
+				Name:  "jonathan",
+				Email: "jonathan@uservoice.com",
+			}
+			insertColumns := []string{"name", "email"}
+			if sess.Dialect == dialect.PostgreSQL {
+				jonathan.Id = 1
+				insertColumns = []string{"id", "name", "email"}
+			}
+			// insert
+			result, err := sess.InsertInto("dbr_people").Columns(insertColumns...).Record(&jonathan).Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		require.True(t, jonathan.Id > 0)
-		// select
-		var people []dbrPerson
-		count, err := sess.Select("*").From("dbr_people").Where(Eq("id", jonathan.Id)).Load(&people)
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-		require.Equal(t, jonathan.Id, people[0].Id)
-		require.Equal(t, jonathan.Name, people[0].Name)
-		require.Equal(t, jonathan.Email, people[0].Email)
+			require.True(t, jonathan.Id > 0)
+			// select
+			var people []dbrPerson
+			count, err := sess.Select("*").From("dbr_people").Where(Eq("id", jonathan.Id)).Load(&people)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+			require.Equal(t, jonathan.Id, people[0].Id)
+			require.Equal(t, jonathan.Name, people[0].Name)
+			require.Equal(t, jonathan.Email, people[0].Email)
 
-		// select id
-		ids, err := sess.Select("id").From("dbr_people").ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(ids))
+			// select id
+			ids, err := sess.Select("id").From("dbr_people").ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(ids))
 
-		// select id limit
-		ids, err = sess.Select("id").From("dbr_people").Limit(1).ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(ids))
+			// select id limit
+			ids, err = sess.Select("id").From("dbr_people").Limit(1).ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(ids))
 
-		// update
-		result, err = sess.Update("dbr_people").Where(Eq("id", jonathan.Id)).Set("name", "jonathan1").Exec()
-		require.NoError(t, err)
+			// update
+			result, err = sess.Update("dbr_people").Where(Eq("id", jonathan.Id)).Set("name", "jonathan1").Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err = result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err = result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		var n NullInt64
-		sess.Select("count(*)").From("dbr_people").Where("name = ?", "jonathan1").LoadOne(&n)
-		require.Equal(t, int64(1), n.Int64)
+			var n NullInt64
+			sess.Select("count(*)").From("dbr_people").Where("name = ?", "jonathan1").LoadOne(&n)
+			require.Equal(t, int64(1), n.Int64)
 
-		// delete
-		result, err = sess.DeleteFrom("dbr_people").Where(Eq("id", jonathan.Id)).Exec()
-		require.NoError(t, err)
+			// delete
+			result, err = sess.DeleteFrom("dbr_people").Where(Eq("id", jonathan.Id)).Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err = result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err = result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		// select id
-		ids, err = sess.Select("id").From("dbr_people").ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 0, len(ids))
+			// select id
+			ids, err = sess.Select("id").From("dbr_people").ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(ids))
+		})
 	}
 }
 
 func TestTimeout(t *testing.T) {
-	mysqlSession := createSession("mysql", mysqlDSN)
-	postgresSession := createSession("postgres", postgresDSN)
-	sqlite3Session := createSession("sqlite3", sqlite3DSN)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-	// all test sessions should be here
-	testSession := []*Session{mysqlSession, postgresSession, sqlite3Session}
+			// session op timeout
+			sess.Timeout = time.Nanosecond
+			var people []dbrPerson
+			_, err := sess.Select("*").From("dbr_people").Load(&people)
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
 
-	for _, sess := range testSession {
-		reset(t, sess)
+			_, err = sess.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		// session op timeout
-		sess.Timeout = time.Nanosecond
-		var people []dbrPerson
-		_, err := sess.Select("*").From("dbr_people").Load(&people)
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = sess.Update("dbr_people").Set("name", "test1").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		_, err = sess.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = sess.DeleteFrom("dbr_people").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		_, err = sess.Update("dbr_people").Set("name", "test1").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
+			// tx op timeout
+			sess.Timeout = 0
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
+			tx.Timeout = time.Nanosecond
 
-		_, err = sess.DeleteFrom("dbr_people").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = tx.Select("*").From("dbr_people").Load(&people)
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		// tx op timeout
-		sess.Timeout = 0
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
-		tx.Timeout = time.Nanosecond
+			_, err = tx.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		_, err = tx.Select("*").From("dbr_people").Load(&people)
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.Update("dbr_people").Set("name", "test1").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		_, err = tx.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-
-		_, err = tx.Update("dbr_people").Set("name", "test1").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-
-		_, err = tx.DeleteFrom("dbr_people").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.DeleteFrom("dbr_people").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+		})
 	}
 }

--- a/example_test.go
+++ b/example_test.go
@@ -151,12 +151,12 @@ func ExampleUnion() {
 	Union(
 		Select("*"),
 		Select("*"),
-	).As("subquery")
+	)
 }
 
 func ExampleUnionAll() {
 	UnionAll(
 		Select("*"),
 		Select("*"),
-	).As("subquery")
+	)
 }

--- a/select.go
+++ b/select.go
@@ -316,7 +316,7 @@ func (b *SelectStmt) FullJoin(table, on interface{}) *SelectStmt {
 
 // As creates alias for select statement.
 func (b *SelectStmt) As(alias string) Builder {
-	return as(b, alias)
+	return as((*selectStmtNoParens)(b), alias)
 }
 
 // Rows executes the query and returns the rows returned, or any error encountered.

--- a/select_test.go
+++ b/select_test.go
@@ -43,132 +43,144 @@ func (ss *stringSliceWithSQLScanner) Scan(src interface{}) error {
 }
 
 func TestSliceWithSQLScannerSelect(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		_, err := sess.InsertInto("dbr_people").
-			Columns("name", "email").
-			Values("test1", "test1@test.com").
-			Values("test2", "test2@test.com").
-			Values("test3", "test3@test.com").
-			Exec()
+			_, err := sess.InsertInto("dbr_people").
+				Columns("name", "email").
+				Values("test1", "test1@test.com").
+				Values("test2", "test2@test.com").
+				Values("test3", "test3@test.com").
+				Exec()
 
-		//plain string slice (original behavior)
-		var stringSlice []string
-		cnt, err := sess.Select("name").From("dbr_people").Load(&stringSlice)
+			//plain string slice (original behavior)
+			var stringSlice []string
+			cnt, err := sess.Select("name").From("dbr_people").Load(&stringSlice)
 
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, stringSlice, 3)
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, stringSlice, 3)
 
-		//string slice with sql.Scanner implemented, should act as a single record
-		var sliceScanner stringSliceWithSQLScanner
-		cnt, err = sess.Select("name").From("dbr_people").Load(&sliceScanner)
+			//string slice with sql.Scanner implemented, should act as a single record
+			var sliceScanner stringSliceWithSQLScanner
+			cnt, err = sess.Select("name").From("dbr_people").Load(&sliceScanner)
 
-		require.NoError(t, err)
-		require.Equal(t, 1, cnt)
-		require.Len(t, sliceScanner, 1)
+			require.NoError(t, err)
+			require.Equal(t, 1, cnt)
+			require.Len(t, sliceScanner, 1)
+		})
 	}
 }
 
 func TestMaps(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		_, err := sess.InsertInto("dbr_people").
-			Columns("name", "email").
-			Values("test1", "test1@test.com").
-			Values("test2", "test2@test.com").
-			Values("test2", "test3@test.com").
-			Exec()
+			_, err := sess.InsertInto("dbr_people").
+				Columns("name", "email").
+				Values("test1", "test1@test.com").
+				Values("test2", "test2@test.com").
+				Values("test2", "test3@test.com").
+				Exec()
 
-		var m map[string]string
-		cnt, err := sess.Select("email, name").From("dbr_people").Load(&m)
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, m, 3)
-		require.Equal(t, "test1", m["test1@test.com"])
+			var m map[string]string
+			cnt, err := sess.Select("email, name").From("dbr_people").Load(&m)
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, m, 3)
+			require.Equal(t, "test1", m["test1@test.com"])
 
-		var m2 map[int64]*dbrPerson
-		cnt, err = sess.Select("id, name, email").From("dbr_people").Load(&m2)
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, m2, 3)
-		require.Equal(t, "test1@test.com", m2[1].Email)
-		require.Equal(t, "test1", m2[1].Name)
-		// the id value is used as the map key, so it is not hydrated in the struct
-		require.Equal(t, int64(0), m2[1].Id)
+			var m2 map[int64]*dbrPerson
+			cnt, err = sess.Select("id, name, email").From("dbr_people").Load(&m2)
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, m2, 3)
+			require.Equal(t, "test1@test.com", m2[1].Email)
+			require.Equal(t, "test1", m2[1].Name)
+			// the id value is used as the map key, so it is not hydrated in the struct
+			require.Equal(t, int64(0), m2[1].Id)
 
-		var m3 map[string][]string
-		cnt, err = sess.Select("name, email").From("dbr_people").OrderAsc("id").Load(&m3)
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, m3, 2)
-		require.Equal(t, []string{"test1@test.com"}, m3["test1"])
-		require.Equal(t, []string{"test2@test.com", "test3@test.com"}, m3["test2"])
+			var m3 map[string][]string
+			cnt, err = sess.Select("name, email").From("dbr_people").OrderAsc("id").Load(&m3)
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, m3, 2)
+			require.Equal(t, []string{"test1@test.com"}, m3["test1"])
+			require.Equal(t, []string{"test2@test.com", "test3@test.com"}, m3["test2"])
 
-		var set map[string]struct{}
-		cnt, err = sess.Select("name").From("dbr_people").Load(&set)
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, set, 2)
-		_, ok := set["test1"]
-		require.True(t, ok)
+			var set map[string]struct{}
+			cnt, err = sess.Select("name").From("dbr_people").Load(&set)
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, set, 2)
+			_, ok := set["test1"]
+			require.True(t, ok)
+		})
 	}
 }
 
 func TestSelectRows(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		_, err := sess.InsertInto("dbr_people").
-			Columns("name", "email").
-			Values("test1", "test1@test.com").
-			Values("test2", "test2@test.com").
-			Values("test3", "test3@test.com").
-			Exec()
+			_, err := sess.InsertInto("dbr_people").
+				Columns("name", "email").
+				Values("test1", "test1@test.com").
+				Values("test2", "test2@test.com").
+				Values("test3", "test3@test.com").
+				Exec()
 
-		rows, err := sess.Select("*").From("dbr_people").OrderAsc("id").Rows()
-		require.NoError(t, err)
-		defer rows.Close()
+			rows, err := sess.Select("*").From("dbr_people").OrderAsc("id").Rows()
+			require.NoError(t, err)
+			defer rows.Close()
 
-		want := []dbrPerson{
-			{Id: 1, Name: "test1", Email: "test1@test.com"},
-			{Id: 2, Name: "test2", Email: "test2@test.com"},
-			{Id: 3, Name: "test3", Email: "test3@test.com"},
-		}
+			want := []dbrPerson{
+				{Id: 1, Name: "test1", Email: "test1@test.com"},
+				{Id: 2, Name: "test2", Email: "test2@test.com"},
+				{Id: 3, Name: "test3", Email: "test3@test.com"},
+			}
 
-		count := 0
-		for rows.Next() {
-			var p dbrPerson
-			require.NoError(t, rows.Scan(&p.Id, &p.Name, &p.Email))
-			require.Equal(t, want[count], p)
-			count++
-		}
+			count := 0
+			for rows.Next() {
+				var p dbrPerson
+				require.NoError(t, rows.Scan(&p.Id, &p.Name, &p.Email))
+				require.Equal(t, want[count], p)
+				count++
+			}
 
-		require.Equal(t, len(want), count)
+			require.Equal(t, len(want), count)
+		})
 	}
 }
 
 func TestInterfaceLoader(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		_, err := sess.InsertInto("dbr_people").
-			Columns("name", "email").
-			Values("test1", "test1@test.com").
-			Values("test2", "test2@test.com").
-			Values("test2", "test3@test.com").
-			Exec()
+			_, err := sess.InsertInto("dbr_people").
+				Columns("name", "email").
+				Values("test1", "test1@test.com").
+				Values("test2", "test2@test.com").
+				Values("test2", "test3@test.com").
+				Exec()
 
-		var m []interface{}
-		cnt, err := sess.Select("*").From("dbr_people").Load(InterfaceLoader(&m, dbrPerson{}))
-		require.NoError(t, err)
-		require.Equal(t, 3, cnt)
-		require.Len(t, m, 3)
-		person, ok := m[0].(dbrPerson)
-		require.True(t, ok)
-		require.Equal(t, "test1", person.Name)
+			var m []interface{}
+			cnt, err := sess.Select("*").From("dbr_people").Load(InterfaceLoader(&m, dbrPerson{}))
+			require.NoError(t, err)
+			require.Equal(t, 3, cnt)
+			require.Len(t, m, 3)
+			person, ok := m[0].(dbrPerson)
+			require.True(t, ok)
+			require.Equal(t, "test1", person.Name)
+		})
 	}
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -7,61 +7,67 @@ import (
 )
 
 func TestTransactionCommit(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
 
-		id := 1
+			id := 1
 
-		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
-		require.NoError(t, err)
-		require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.exec")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
-		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
-		require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
+			result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
+			require.NoError(t, err)
+			require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.exec")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")
+			require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).finished)
+			require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		err = tx.Commit()
-		require.NoError(t, err)
+			err = tx.Commit()
+			require.NoError(t, err)
 
-		var person dbrPerson
-		err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
-		require.Error(t, err)
-		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+			var person dbrPerson
+			err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
+			require.Error(t, err)
+			require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+		})
 	}
 }
 
 func TestTransactionRollback(t *testing.T) {
-	for _, sess := range testSession {
-		reset(t, sess)
+	for _, test := range testSession {
+		t.Run(test.Test, func(t *testing.T) {
+			sess := test.Sess
+			reset(t, sess)
 
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
 
-		id := 1
+			id := 1
 
-		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
-		require.NoError(t, err)
+			result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		err = tx.Rollback()
-		require.NoError(t, err)
+			err = tx.Rollback()
+			require.NoError(t, err)
 
-		var person dbrPerson
-		err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
-		require.Error(t, err)
+			var person dbrPerson
+			err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
+			require.Error(t, err)
+		})
 	}
 }


### PR DESCRIPTION
Previously sub SELECTS were always wrapped in parentheses which resulted
in invalid SQL syntax for UNIONs for sqlite3 and for SELECT...AS for
MySQL as reported by Issue #167.

Now SelectStmts are type cast to a builder type that hides the
SelectStmt type from interpolate().

Additionally all tests were improved by adding subtests for each SQL
driver. This allows tests for all drivers to continue to be run even if
a test for a single driver fails.