### PR TITLE
Fix examples of receiving autoincrementing IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sugg := &Suggestion{
 }
 sess := mysqlSession
 sess.InsertInto("suggestions").
-	Columns("id", "title").
+	Columns("title").
 	Record(&sugg).
 	Exec()
 

--- a/example_test.go
+++ b/example_test.go
@@ -97,7 +97,7 @@ func ExampleInsertStmt_Record() {
 	}
 	sess := mysqlSession
 	sess.InsertInto("suggestions").
-		Columns("id", "title").
+		Columns("title").
 		Record(&sugg).
 		Exec()
 


### PR DESCRIPTION
My understanding is that if you specify `id` as one of the arguments to `Columns()`, then the id will be included in the INSERT statement explicitly, rather than accepting the auto-increment default. In the example, that would explicitly set it to `0` (Go's zero value for int64).

This merge request fixes the examples.