### PR TITLE
support pgx/stdlib to drive PostgreSQL.

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -24,7 +24,7 @@ func Open(driver, dsn string, log EventReceiver) (*Connection, error) {
 	switch driver {
 	case "mysql":
 		d = dialect.MySQL
-	case "postgres":
+	case "postgres", "pgx":
 		d = dialect.PostgreSQL
 	case "sqlite3":
 		d = dialect.SQLite3


### PR DESCRIPTION
Someone like me connect PostgreSQL with jackc/pgx.
jackc/pgx is not compatible with database/sql, but it given a database/sql compatibility layer by jackc/pgx/stdlib.
jackc/pgx use "pgx" as driver indicator, so connect PostgreSQL with pgx like below:
```go
db, err := dbr.Open("pgx", "user=pguser password=secret dbname=mydb sslmode=disable", nil)
if err != nil {
	log.Fatalln(err)
}
...
```