### PR TITLE
SQL Comment Support

### DIFF
--- a/comments.go
+++ b/comments.go
@@ -1,0 +1,34 @@
+package dbr
+
+import "strings"
+
+const (
+	OPENING_SQL_COMMENT = "/*"
+	CLOSING_SQL_COMMENT = "*/"
+	SPACE               = " "
+	NEWLINE             = "\n"
+	EMPTY_STRING        = ""
+)
+
+// Comments represents a set of mysql comments
+type Comments []string
+
+func (comments Comments) Append(comment string) Comments {
+	comment = strings.Replace(comment, OPENING_SQL_COMMENT, EMPTY_STRING, -1)
+	comment = strings.Replace(comment, CLOSING_SQL_COMMENT, EMPTY_STRING, -1)
+	comment = strings.TrimSpace(comment)
+	comments = append(comments, comment)
+	return comments
+}
+
+// Write will write each comment in the form of "/* some comment */\n"
+func (comments Comments) Write(buf Buffer) {
+	for _, comment := range comments {
+		buf.WriteString(OPENING_SQL_COMMENT)
+		buf.WriteString(SPACE)
+		buf.WriteString(comment)
+		buf.WriteString(SPACE)
+		buf.WriteString(CLOSING_SQL_COMMENT)
+		buf.WriteString(NEWLINE)
+	}
+}

--- a/comments.go
+++ b/comments.go
@@ -3,19 +3,20 @@ package dbr
 import "strings"
 
 const (
-	OPENING_SQL_COMMENT = "/*"
-	CLOSING_SQL_COMMENT = "*/"
-	SPACE               = " "
-	NEWLINE             = "\n"
-	EMPTY_STRING        = ""
+	openingSQLComment = "/*"
+	closingSQLComment = "*/"
+	space             = " "
+	newline           = "\n"
+	emptyString       = ""
 )
 
 // Comments represents a set of mysql comments
 type Comments []string
 
+// Append a new sql comment to a set of comments
 func (comments Comments) Append(comment string) Comments {
-	comment = strings.Replace(comment, OPENING_SQL_COMMENT, EMPTY_STRING, -1)
-	comment = strings.Replace(comment, CLOSING_SQL_COMMENT, EMPTY_STRING, -1)
+	comment = strings.Replace(comment, openingSQLComment, emptyString, -1)
+	comment = strings.Replace(comment, closingSQLComment, emptyString, -1)
 	comment = strings.TrimSpace(comment)
 	comments = append(comments, comment)
 	return comments
@@ -24,11 +25,11 @@ func (comments Comments) Append(comment string) Comments {
 // Write will write each comment in the form of "/* some comment */\n"
 func (comments Comments) Write(buf Buffer) {
 	for _, comment := range comments {
-		buf.WriteString(OPENING_SQL_COMMENT)
-		buf.WriteString(SPACE)
+		buf.WriteString(openingSQLComment)
+		buf.WriteString(space)
 		buf.WriteString(comment)
-		buf.WriteString(SPACE)
-		buf.WriteString(CLOSING_SQL_COMMENT)
-		buf.WriteString(NEWLINE)
+		buf.WriteString(space)
+		buf.WriteString(closingSQLComment)
+		buf.WriteString(newline)
 	}
 }

--- a/comments.go
+++ b/comments.go
@@ -22,14 +22,15 @@ func (comments Comments) Append(comment string) Comments {
 	return comments
 }
 
-// Write will write each comment in the form of "/* some comment */\n"
-func (comments Comments) Write(buf Buffer) {
+// Build writes each comment in the form of "/* some comment */\n"
+func (comments Comments) Build(d Dialect, buf Buffer) error {
 	for _, comment := range comments {
-		buf.WriteString(openingSQLComment)
-		buf.WriteString(space)
-		buf.WriteString(comment)
-		buf.WriteString(space)
-		buf.WriteString(closingSQLComment)
-		buf.WriteString(newline)
+		words := []string{openingSQLComment, space, comment, space, closingSQLComment, newline}
+		for _, str := range words {
+			if _, err := buf.WriteString(str); err != nil {
+				return err
+			}
+		}
 	}
+	return nil
 }

--- a/comments.go
+++ b/comments.go
@@ -10,7 +10,7 @@ const (
 	emptyString       = ""
 )
 
-// Comments represents a set of mysql comments
+// Comments represents a set of sql comments
 type Comments []string
 
 // Append a new sql comment to a set of comments

--- a/comments_test.go
+++ b/comments_test.go
@@ -1,0 +1,36 @@
+package dbr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestComments(t *testing.T) {
+	for _, test := range []struct {
+		comments Comments
+		expect   string
+	}{
+		{
+			comments: Comments.Append(nil, "test comment").Append("another comment"),
+			expect:   "/* test comment */\n/* another comment */\n",
+		},
+		{
+			comments: Comments.Append(nil, "test comment\nwith a newline").Append("another comment\nwith a newline"),
+			expect:   "/* test comment\nwith a newline */\n/* another comment\nwith a newline */\n",
+		},
+		{
+			comments: Comments.Append(nil, "test comment\nwith a newline").Append("another comment\nwith a newline"),
+			expect:   "/* test comment\nwith a newline */\n/* another comment\nwith a newline */\n",
+		},
+		{
+			comments: Comments.Append(nil, "/* test nested comment removed */"),
+			expect:   "/* test nested comment removed */\n",
+		},
+	} {
+		buf := NewBuffer()
+		test.comments.Write(buf)
+		require.Equal(t, test.expect, buf.String())
+	}
+
+}

--- a/comments_test.go
+++ b/comments_test.go
@@ -3,34 +3,50 @@ package dbr
 import (
 	"testing"
 
+	"github.com/gocraft/dbr/dialect"
 	"github.com/stretchr/testify/require"
 )
 
 func TestComments(t *testing.T) {
+	dialects := []Dialect{dialect.MySQL, dialect.PostgreSQL, dialect.SQLite3}
 	for _, test := range []struct {
+		name     string
 		comments Comments
 		expect   string
 	}{
 		{
+			name:     "test comment",
 			comments: Comments.Append(nil, "test comment").Append("another comment"),
 			expect:   "/* test comment */\n/* another comment */\n",
 		},
 		{
+			name:     "test comment with newline",
 			comments: Comments.Append(nil, "test comment\nwith a newline").Append("another comment\nwith a newline"),
 			expect:   "/* test comment\nwith a newline */\n/* another comment\nwith a newline */\n",
 		},
 		{
-			comments: Comments.Append(nil, "test comment\nwith a newline").Append("another comment\nwith a newline"),
-			expect:   "/* test comment\nwith a newline */\n/* another comment\nwith a newline */\n",
-		},
-		{
+			name:     "test nested comment removed",
 			comments: Comments.Append(nil, "/* test nested comment removed */"),
 			expect:   "/* test nested comment removed */\n",
 		},
 	} {
-		buf := NewBuffer()
-		test.comments.Write(buf)
-		require.Equal(t, test.expect, buf.String())
+
+		for _, d := range dialects {
+			name := ""
+			switch d {
+			case dialect.MySQL:
+				name = "MySQL"
+			case dialect.PostgreSQL:
+				name = "PostgreSQL"
+			case dialect.SQLite3:
+				name = "SQLite3"
+			}
+			t.Run(name+" "+test.name, func(t *testing.T) {
+				buf := NewBuffer()
+				test.comments.Build(d, buf)
+				require.Equal(t, test.expect, buf.String())
+			})
+		}
 	}
 
 }

--- a/delete.go
+++ b/delete.go
@@ -32,7 +32,7 @@ func (b *DeleteStmt) Build(d Dialect, buf Buffer) error {
 		return ErrTableNotSpecified
 	}
 
-	b.comments.Write(buf)
+	b.comments.Build(d, buf)
 
 	buf.WriteString("DELETE FROM ")
 	buf.WriteString(d.QuoteIdent(b.Table))

--- a/delete.go
+++ b/delete.go
@@ -17,6 +17,8 @@ type DeleteStmt struct {
 	Table      string
 	WhereCond  []Builder
 	LimitCount int64
+
+	comments Comments
 }
 
 type DeleteBuilder = DeleteStmt
@@ -29,6 +31,8 @@ func (b *DeleteStmt) Build(d Dialect, buf Buffer) error {
 	if b.Table == "" {
 		return ErrTableNotSpecified
 	}
+
+	b.comments.Write(buf)
 
 	buf.WriteString("DELETE FROM ")
 	buf.WriteString(d.QuoteIdent(b.Table))
@@ -116,6 +120,11 @@ func (b *DeleteStmt) Where(query interface{}, value ...interface{}) *DeleteStmt 
 
 func (b *DeleteStmt) Limit(n uint64) *DeleteStmt {
 	b.LimitCount = int64(n)
+	return b
+}
+
+func (b *DeleteStmt) Comment(comment string) *DeleteStmt {
+	b.comments = b.comments.Append(comment)
 	return b
 }
 

--- a/delete_test.go
+++ b/delete_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestDeleteStmt(t *testing.T) {
 	buf := NewBuffer()
-	builder := DeleteFrom("table").Where(Eq("a", 1))
+	builder := DeleteFrom("table").Where(Eq("a", 1)).Comment("DELETE TEST")
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
-	require.Equal(t, "DELETE FROM `table` WHERE (`a` = ?)", buf.String())
+	require.Equal(t, "/* DELETE TEST */\nDELETE FROM `table` WHERE (`a` = ?)", buf.String())
 	require.Equal(t, []interface{}{1}, buf.Value())
 }
 

--- a/insert.go
+++ b/insert.go
@@ -20,6 +20,7 @@ type InsertStmt struct {
 	Value        [][]interface{}
 	ReturnColumn []string
 	RecordID     *int64
+	comments     Comments
 }
 
 type InsertBuilder = InsertStmt
@@ -36,6 +37,8 @@ func (b *InsertStmt) Build(d Dialect, buf Buffer) error {
 	if len(b.Column) == 0 {
 		return ErrColumnNotSpecified
 	}
+
+	b.comments.Write(buf)
 
 	buf.WriteString("INSERT INTO ")
 	buf.WriteString(d.QuoteIdent(b.Table))
@@ -132,6 +135,12 @@ func (tx *Tx) InsertBySql(query string, value ...interface{}) *InsertStmt {
 
 func (b *InsertStmt) Columns(column ...string) *InsertStmt {
 	b.Column = column
+	return b
+}
+
+// Comment adds a comment to prepended. All multi-line sql comment characters are stripped
+func (b *InsertStmt) Comment(comment string) *InsertStmt {
+	b.comments = b.comments.Append(comment)
 	return b
 }
 

--- a/insert.go
+++ b/insert.go
@@ -38,7 +38,7 @@ func (b *InsertStmt) Build(d Dialect, buf Buffer) error {
 		return ErrColumnNotSpecified
 	}
 
-	b.comments.Write(buf)
+	b.comments.Build(d, buf)
 
 	buf.WriteString("INSERT INTO ")
 	buf.WriteString(d.QuoteIdent(b.Table))

--- a/insert_test.go
+++ b/insert_test.go
@@ -17,10 +17,10 @@ func TestInsertStmt(t *testing.T) {
 	builder := InsertInto("table").Columns("a", "b").Values(1, "one").Record(&insertTest{
 		A: 2,
 		C: "two",
-	})
+	}).Comment("INSERT TEST")
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
-	require.Equal(t, "INSERT INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())
+	require.Equal(t, "/* INSERT TEST */\nINSERT INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())
 	require.Equal(t, []interface{}{1, "one", 2, "two"}, buf.Value())
 }
 

--- a/select.go
+++ b/select.go
@@ -43,7 +43,7 @@ func (b *SelectStmt) Build(d Dialect, buf Buffer) error {
 		return ErrColumnNotSpecified
 	}
 
-	b.comments.Write(buf)
+	b.comments.Build(d, buf)
 
 	buf.WriteString("SELECT ")
 

--- a/select.go
+++ b/select.go
@@ -28,6 +28,8 @@ type SelectStmt struct {
 
 	LimitCount  int64
 	OffsetCount int64
+
+	comments Comments
 }
 
 type SelectBuilder = SelectStmt
@@ -40,6 +42,8 @@ func (b *SelectStmt) Build(d Dialect, buf Buffer) error {
 	if len(b.Column) == 0 {
 		return ErrColumnNotSpecified
 	}
+
+	b.comments.Write(buf)
 
 	buf.WriteString("SELECT ")
 
@@ -301,6 +305,11 @@ func (b *SelectStmt) OrderDir(col string, isAsc bool) *SelectStmt {
 	} else {
 		b.OrderDesc(col)
 	}
+	return b
+}
+
+func (b *SelectStmt) Comment(comment string) *SelectStmt {
+	b.comments = b.comments.Append(comment)
 	return b
 }
 

--- a/select_test.go
+++ b/select_test.go
@@ -21,11 +21,12 @@ func TestSelectStmt(t *testing.T) {
 		OrderAsc("f").
 		Limit(3).
 		Offset(4).
-		Suffix("FOR UPDATE")
+		Suffix("FOR UPDATE").
+		Comment("SELECT TEST")
 
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
-	require.Equal(t, "SELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4 FOR UPDATE", buf.String())
+	require.Equal(t, "/* SELECT TEST */\nSELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4 FOR UPDATE", buf.String())
 	// two functions cannot be compared
 	require.Equal(t, 3, len(buf.Value()))
 }

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -16,10 +16,11 @@ func TestTransactionCommit(t *testing.T) {
 
 		id := 1
 
-		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
+		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Comment("INSERT TEST").Exec()
 		require.NoError(t, err)
 		require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, 1)
 		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].eventName, "dbr.exec")
+		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "/* INSERT TEST */\n")
 		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "INSERT")
 		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "dbr_people")
 		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[0].query, "name")

--- a/update.go
+++ b/update.go
@@ -37,7 +37,7 @@ func (b *UpdateStmt) Build(d Dialect, buf Buffer) error {
 		return ErrColumnNotSpecified
 	}
 
-	b.comments.Write(buf)
+	b.comments.Build(d, buf)
 
 	buf.WriteString("UPDATE ")
 	buf.WriteString(d.QuoteIdent(b.Table))

--- a/update.go
+++ b/update.go
@@ -19,6 +19,7 @@ type UpdateStmt struct {
 	WhereCond    []Builder
 	ReturnColumn []string
 	LimitCount   int64
+	comments     Comments
 }
 
 type UpdateBuilder = UpdateStmt
@@ -35,6 +36,8 @@ func (b *UpdateStmt) Build(d Dialect, buf Buffer) error {
 	if len(b.Value) == 0 {
 		return ErrColumnNotSpecified
 	}
+
+	b.comments.Write(buf)
 
 	buf.WriteString("UPDATE ")
 	buf.WriteString(d.QuoteIdent(b.Table))
@@ -170,6 +173,11 @@ func (b *UpdateStmt) SetMap(m map[string]interface{}) *UpdateStmt {
 
 func (b *UpdateStmt) Limit(n uint64) *UpdateStmt {
 	b.LimitCount = int64(n)
+	return b
+}
+
+func (b *UpdateStmt) Comment(comment string) *UpdateStmt {
+	b.comments = b.comments.Append(comment)
 	return b
 }
 

--- a/update_test.go
+++ b/update_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestUpdateStmt(t *testing.T) {
 	buf := NewBuffer()
-	builder := Update("table").Set("a", 1).Where(Eq("b", 2))
+	builder := Update("table").Set("a", 1).Where(Eq("b", 2)).Comment("UPDATE TEST")
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
 
-	require.Equal(t, "UPDATE `table` SET `a` = ? WHERE (`b` = ?)", buf.String())
+	require.Equal(t, "/* UPDATE TEST */\nUPDATE `table` SET `a` = ? WHERE (`b` = ?)", buf.String())
 	require.Equal(t, []interface{}{1, 2}, buf.Value())
 }
 


### PR DESCRIPTION
Adds support for comments of the form:
```
/* some comment */
/* another comment */
SELECT * FROM table WHERE ...
```

This will allow developers to annotate queries with comments and view them in slow query logs, to aid in debugging and backtracing queries to application code.