### PR TITLE
Check rows.Err() on Load addresses issue #182

### DIFF
--- a/load.go
+++ b/load.go
@@ -122,7 +122,7 @@ func Load(rows *sql.Rows, value interface{}) (int, error) {
 			break
 		}
 	}
-	return count, nil
+	return count, rows.Err()
 }
 
 func reflectAlloc(typ reflect.Type) reflect.Value {


### PR DESCRIPTION
Passes error down the line so `InsertStmt.Load` will properly error on constraints.