### PR TITLE
Repair CI by setting POSTGRES_PASSWORD env variable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,8 @@ jobs:
           - MYSQL_DATABASE=circle_test
           - MYSQL_ROOT_PASSWORD=root
       - image: postgres:11-alpine
+        environment:
+          - POSTGRES_PASSWORD=mysecretpassword
 
     working_directory: /go/src/github.com/gocraft/dbr
     steps:


### PR DESCRIPTION
Seems like CI is broken now, it fails when I try to run this locally:
```
$ circleci local execute --job build --config .circleci/config.yml

...
Error: Database is uninitialized and superuser password is not specified.  
       You must specify POSTGRES_PASSWORD for the superuser. Use                                                                                                                                                
       "-e POSTGRES_PASSWORD=password" to set it in "docker run".                                                                                                                                               
                                                                                                                                     
       You may also use POSTGRES_HOST_AUTH_METHOD=trust to allow all connections                                                                                                                                
       without a password. This is *not* recommended. See PostgreSQL                                                                                                                                            
       documentation about "trust":                                                                                                     
       https://www.postgresql.org/docs/current/auth-trust.html                                                                            
Error:                                                                                                                                                                                                          
Exited with code 1

Step failed
...

====>> Wait for db                                                                                         
  #!/bin/bash -eo pipefail                                                                                 
dockerize -wait tcp://127.0.0.1:3306 -wait tcp://127.0.0.1:5432 -timeout 1m                                
2020/02/17 11:38:43 Waiting for host: 127.0.0.1:3306                                                       
2020/02/17 11:38:43 Waiting for host: 127.0.0.1:5432                                                       
2020/02/17 11:38:43 Problem with dial: dial tcp 127.0.0.1:3306: getsockopt: connection refused. Sleeping 5s
...
2020/02/17 11:38:53 Problem with dial: dial tcp 127.0.0.1:5432: getsockopt: connection refused. Sleeping 5s
2020/02/17 11:38:53 Connected to tcp://127.0.0.1:3306
...
2020/02/17 11:39:38 Problem with dial: dial tcp 127.0.0.1:5432: getsockopt: connection refused. Sleeping 5s
2020/02/17 11:39:43 Timeout after 1m0s waiting on dependencies to become available: [tcp://127.0.0.1:3306 tcp://127.0.0.1:5432]
Error:
Exited with code exit status 1

Step failed
Error: runner failed (exited with 101)
Task failed
Step canceled
Error: task failed
```

Maintainer of postgres:11-alpine docker image decided to make it more secure by default, so now either the `POSTGRES_PASSWORD` should be set, or `POSTGRES_HOST_AUTH_METHOD` should have `trust` value.

More info can be found here: https://github.com/docker-library/postgres/issues/681#issuecomment-586517154

Commit in docker-library/postgres: https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc