### PR TITLE
Add quoteindent for select builder table name

### DIFF
--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -104,7 +104,7 @@ func TestInterpolateForDialect(t *testing.T) {
 		{
 			query: "?",
 			value: []interface{}{Select("a").From("table")},
-			want:  "SELECT a FROM table",
+			want:  "SELECT a FROM `table`",
 		},
 		{
 			query: "?",
@@ -114,7 +114,7 @@ func TestInterpolateForDialect(t *testing.T) {
 		{
 			query: "?",
 			value: []interface{}{Select("a").From("table").As("a1")},
-			want:  "(SELECT a FROM table) AS `a1`",
+			want:  "(SELECT a FROM `table`) AS `a1`",
 		},
 		{
 			query: "?",
@@ -126,7 +126,7 @@ func TestInterpolateForDialect(t *testing.T) {
 			},
 			// parentheses around union subqueries are not supported in sqlite
 			// but supported in both mysql and postgres.
-			want: "(SELECT a FROM table1 UNION ALL SELECT b FROM table2) AS `t`",
+			want: "(SELECT a FROM `table1` UNION ALL SELECT b FROM `table2`) AS `t`",
 		},
 		{
 			query: "?",

--- a/select.go
+++ b/select.go
@@ -73,6 +73,7 @@ func (b *SelectStmt) Build(d Dialect, buf Buffer) error {
 		switch table := b.Table.(type) {
 		case string:
 			buf.WriteString(b.QuoteIdent(table))
+			buf.WriteString(d.QuoteIdent(table))
 		default:
 			buf.WriteString(placeholder)
 			buf.WriteValue(table)

--- a/select.go
+++ b/select.go
@@ -72,8 +72,7 @@ func (b *SelectStmt) Build(d Dialect, buf Buffer) error {
 		buf.WriteString(" FROM ")
 		switch table := b.Table.(type) {
 		case string:
-			// FIXME: no quote ident
-			buf.WriteString(table)
+			buf.WriteString(b.QuoteIdent(table))
 		default:
 			buf.WriteString(placeholder)
 			buf.WriteValue(table)


### PR DESCRIPTION
Makes select consistent with the other query builders for the table naming in generated queries. 

Before this, running a e2e lifecycle test where select, insert, update, and delete are all called for the same table/resource/relation in a postgres db, the select statement would fail because the relation could not be found. The other queries would all succeed.