### PR TITLE
bugfix limit offset when no limitCount isset or is zero

### DIFF
--- a/select.go
+++ b/select.go
@@ -3,6 +3,7 @@ package dbr
 import (
 	"context"
 	"database/sql"
+	"github.com/gocraft/dbr/v2/dialect"
 	"strconv"
 )
 
@@ -130,12 +131,21 @@ func (b *SelectStmt) Build(d Dialect, buf Buffer) error {
 		}
 	}
 
-	if b.LimitCount >= 0 {
+	if b.LimitCount > 0 || b.OffsetCount > 0 {
 		buf.WriteString(" LIMIT ")
-		buf.WriteString(strconv.FormatInt(b.LimitCount, 10))
+
+		if b.LimitCount == 0 {
+			if b.Dialect == dialect.PostgreSQL {
+				buf.WriteString("ALL")
+			} else {
+				buf.WriteString("18446744073709551615")
+			}
+		} else {
+			buf.WriteString(strconv.FormatInt(b.LimitCount, 10))
+		}
 	}
 
-	if b.OffsetCount >= 0 {
+	if b.OffsetCount > 0 {
 		buf.WriteString(" OFFSET ")
 		buf.WriteString(strconv.FormatInt(b.OffsetCount, 10))
 	}


### PR DESCRIPTION
When the limit count has no value (0) the LIMIT keyword is not written. 
This results in an error when using MySQL. Because the limit keyword is required when specifying the offset in MySQL. For Postgres it fine to omit the LIMIT keyword because it is optional.

I created a fix that the LIMIT will always be specified when a limit or an offset is set. I will have the same behavior for Postgres and MySQL when you omit to set the LimitCount

Postgress will have the ALL keyword. `LIMIT ALL OFFSET 123`
All other dialects will use the maximum value of BIGINT (18446744073709551615) `LIMIT 18446744073709551615  OFFSET 123`

_The BIGINT solution is an alternative way to in MySQL for getting all the results after the offset._

Please let me know if this is an acceptable fix and if there are additional tests needed.