### PR TITLE
InsertStmt: automatically add insert columns when using InsertStmt.Record()

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.12
+      - image: circleci/golang:1.13
         environment:
           - DBR_TEST_MYSQL_DSN=root:root@tcp(127.0.0.1:3306)/circle_test
           - DBR_TEST_POSTGRES_DSN=postgres://postgres:mysecretpassword@127.0.0.1:5432/postgres?sslmode=disable

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,6 @@ github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.3 h1:j7a/xn1U6TKA/PHHxqZuzh64CdtRc7rU9M+AvkOl5bA=
 github.com/mattn/go-sqlite3 v1.14.3/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible h1:gXHsfypPkaMZrKbD5209QV9jbUTJKjyR5WD3HYQSd+U=
-github.com/mattn/go-sqlite3 v2.0.3+incompatible/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -26,6 +24,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c h1:Vj5n4GlwjmQteupaxJ9+0FNOmBrHfq7vN4btdGoDZgI=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/insert.go
+++ b/insert.go
@@ -197,14 +197,16 @@ func (b *InsertStmt) Record(structValue interface{}) *InsertStmt {
 		// Use the struct fields excluding non exported fields
 		if len(b.Column) == 0 {
 			fields := s.get(v.Type())
-			var i int
-			for x := 0; x < len(fields); x++ {
-				if fields[x] != "" {
-					fields[i] = fields[x]
-					i++
+			for i, field := range fields {
+				if field == "id" {
+					if idField := v.Field(i); idField.IsZero() {
+						continue
+					}
+				}
+				if field != "" {
+					b.Column = append(b.Column, field)
 				}
 			}
-			b.Columns(fields[:i]...)
 		}
 
 		found := make([]interface{}, len(b.Column)+1)

--- a/insert_test.go
+++ b/insert_test.go
@@ -9,6 +9,7 @@ import (
 
 type insertTest struct {
 	A int
+	D string `db:"-"`
 	C string `db:"b"`
 	u int
 }

--- a/insert_test.go
+++ b/insert_test.go
@@ -10,11 +10,24 @@ import (
 type insertTest struct {
 	A int
 	C string `db:"b"`
+	u int
 }
 
 func TestInsertStmt(t *testing.T) {
 	buf := NewBuffer()
 	builder := InsertInto("table").Ignore().Columns("a", "b").Values(1, "one").Record(&insertTest{
+		A: 2,
+		C: "two",
+	}).Comment("INSERT TEST")
+	err := builder.Build(dialect.MySQL, buf)
+	require.NoError(t, err)
+	require.Equal(t, "/* INSERT TEST */\nINSERT IGNORE INTO `table` (`a`,`b`) VALUES (?,?), (?,?)", buf.String())
+	require.Equal(t, []interface{}{1, "one", 2, "two"}, buf.Value())
+}
+
+func TestInsertStmtAutoColumn(t *testing.T) {
+	buf := NewBuffer()
+	builder := InsertInto("table").Ignore().Values(1, "one").Record(&insertTest{
 		A: 2,
 		C: "two",
 	}).Comment("INSERT TEST")


### PR DESCRIPTION
This change automatically adds the insert columns when using 
InsertStmt.Record() if they are not set by calling Columns().

Calling Columns() afterwards still maintains the same behaviour as it 
overwrites the Column field.

Since there is no API incompatibility, this change was made on the 
existing Record() function.