### PR TITLE
add index hints for mysql's SELECT and UPDATE statements

### DIFF
--- a/index_hints.go
+++ b/index_hints.go
@@ -1,0 +1,64 @@
+package dbr
+
+//mysql hint https://dev.mysql.com/doc/refman/8.0/en/index-hints.html
+const (
+	useIndex    = "USE INDEX"
+	ignoreIndex = "IGNORE INDEX"
+	forceIndex  = "FORCE INDEX"
+
+	forJoin    = "FOR JOIN"
+	forOrderBY = "FOR ORDER BY"
+	forGroupBy = "FOR GROUP BY"
+)
+
+type indexHint struct {
+	hint      []string
+	indexList []string
+}
+
+func UseIndex(index ...string) indexHint {
+	return indexHint{hint: []string{useIndex}, indexList: index}
+}
+
+func IgnoreIndex(index ...string) indexHint {
+	return indexHint{hint: []string{ignoreIndex}, indexList: index}
+}
+
+func ForceIndex(index ...string) indexHint {
+	return indexHint{hint: []string{forceIndex}, indexList: index}
+}
+
+func (i indexHint) ForJoin() indexHint {
+	i.hint = append(i.hint, forJoin)
+	return i
+}
+
+func (i indexHint) ForOrderBy() indexHint {
+	i.hint = append(i.hint, forOrderBY)
+	return i
+}
+func (i indexHint) ForGroupBy() indexHint {
+	i.hint = append(i.hint, forGroupBy)
+	return i
+}
+
+func (i indexHint) Build(d Dialect, buf Buffer) error {
+	for idx, v := range i.hint {
+		if idx > 0 {
+			buf.WriteString(" ")
+		}
+		buf.WriteString(v)
+	}
+
+	buf.WriteString("(")
+	for idx, v := range i.indexList {
+		if idx > 0 {
+			buf.WriteString(",")
+		}
+
+		buf.WriteString(d.QuoteIdent(v))
+
+	}
+	buf.WriteString(")")
+	return nil
+}

--- a/select_test.go
+++ b/select_test.go
@@ -22,11 +22,14 @@ func TestSelectStmt(t *testing.T) {
 		Limit(3).
 		Offset(4).
 		Suffix("FOR UPDATE").
-		Comment("SELECT TEST")
+		Comment("SELECT TEST").
+		IndexHint(UseIndex("idx_c_d").ForGroupBy(), "USE INDEX(idx_e_f)").
+		IndexHint(IgnoreIndex("idx_a_b"))
 
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
-	require.Equal(t, "/* SELECT TEST */\nSELECT DISTINCT a, b FROM ? LEFT JOIN `table2` ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4 FOR UPDATE", buf.String())
+	require.Equal(t, "/* SELECT TEST */\nSELECT DISTINCT a, b FROM ? USE INDEX FOR GROUP BY(`idx_c_d`) USE INDEX(idx_e_f) IGNORE INDEX(`idx_a_b`) "+
+		"LEFT JOIN `table2` ON table.a1 = table.a2 WHERE (`c` = ?) GROUP BY d HAVING (`e` = ?) ORDER BY f ASC LIMIT 3 OFFSET 4 FOR UPDATE", buf.String())
 	// two functions cannot be compared
 	require.Equal(t, 3, len(buf.Value()))
 }

--- a/update_test.go
+++ b/update_test.go
@@ -9,11 +9,12 @@ import (
 
 func TestUpdateStmt(t *testing.T) {
 	buf := NewBuffer()
-	builder := Update("table").Set("a", 1).Where(Eq("b", 2)).Comment("UPDATE TEST")
+	builder := Update("table").Set("a", 1).Where(Eq("b", 2)).Comment("UPDATE TEST").
+		IndexHint(ForceIndex("idx_a_b"))
 	err := builder.Build(dialect.MySQL, buf)
 	require.NoError(t, err)
 
-	require.Equal(t, "/* UPDATE TEST */\nUPDATE `table` SET `a` = ? WHERE (`b` = ?)", buf.String())
+	require.Equal(t, "/* UPDATE TEST */\nUPDATE `table` FORCE INDEX(`idx_a_b`) SET `a` = ? WHERE (`b` = ?)", buf.String())
 	require.Equal(t, []interface{}{1, 2}, buf.Value())
 }
 


### PR DESCRIPTION
Add index hints func for mysql. For other db like sqlite3, it can directly write raw index hint sql in `IndexHint()`