### PR TITLE
Add "sqlite" as "sqlite3" dialect alias

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -26,7 +26,7 @@ func Open(driver, dsn string, log EventReceiver) (*Connection, error) {
 		d = dialect.MySQL
 	case "postgres", "pgx":
 		d = dialect.PostgreSQL
-	case "sqlite3":
+	case "sqlite3", "sqlite":
 		d = dialect.SQLite3
 	case "mssql":
 		d = dialect.MSSQL


### PR DESCRIPTION
This will allow us to use the sqlite3 package from modernc.org/sqlite, that doesn't need cgo anymore.