### PR TITLE
TWEAK: Make Runner interface public

### DIFF
--- a/dbr.go
+++ b/dbr.go
@@ -99,13 +99,13 @@ type SessionRunner interface {
 	DeleteBySql(query string, value ...interface{}) *DeleteBuilder
 }
 
-type runner interface {
+type Runner interface {
 	GetTimeout() time.Duration
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
 }
 
-func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect) (sql.Result, error) {
+func exec(ctx context.Context, runner Runner, log EventReceiver, builder Builder, d Dialect) (sql.Result, error) {
 	timeout := runner.GetTimeout()
 	if timeout > 0 {
 		var cancel func()
@@ -152,7 +152,7 @@ func exec(ctx context.Context, runner runner, log EventReceiver, builder Builder
 	return result, nil
 }
 
-func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect) (string, *sql.Rows, error) {
+func queryRows(ctx context.Context, runner Runner, log EventReceiver, builder Builder, d Dialect) (string, *sql.Rows, error) {
 	// discard the timeout set in the runner, the context should not be canceled
 	// implicitly here but explicitly by the caller since the returned *sql.Rows
 	// may still listening to the context
@@ -196,7 +196,7 @@ func queryRows(ctx context.Context, runner runner, log EventReceiver, builder Bu
 	return query, rows, nil
 }
 
-func query(ctx context.Context, runner runner, log EventReceiver, builder Builder, d Dialect, dest interface{}) (int, error) {
+func query(ctx context.Context, runner Runner, log EventReceiver, builder Builder, d Dialect, dest interface{}) (int, error) {
 	timeout := runner.GetTimeout()
 	if timeout > 0 {
 		var cancel func()

--- a/delete.go
+++ b/delete.go
@@ -8,7 +8,7 @@ import (
 
 // DeleteStmt builds `DELETE ...`.
 type DeleteStmt struct {
-	runner
+	Runner
 	EventReceiver
 	Dialect
 
@@ -65,7 +65,7 @@ func DeleteFrom(table string) *DeleteStmt {
 // DeleteFrom creates a DeleteStmt.
 func (sess *Session) DeleteFrom(table string) *DeleteStmt {
 	b := DeleteFrom(table)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -74,7 +74,7 @@ func (sess *Session) DeleteFrom(table string) *DeleteStmt {
 // DeleteFrom creates a DeleteStmt.
 func (tx *Tx) DeleteFrom(table string) *DeleteStmt {
 	b := DeleteFrom(table)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -94,7 +94,7 @@ func DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 // DeleteBySql creates a DeleteStmt from raw query.
 func (sess *Session) DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 	b := DeleteBySql(query, value...)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -103,7 +103,7 @@ func (sess *Session) DeleteBySql(query string, value ...interface{}) *DeleteStmt
 // DeleteBySql creates a DeleteStmt from raw query.
 func (tx *Tx) DeleteBySql(query string, value ...interface{}) *DeleteStmt {
 	b := DeleteBySql(query, value...)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -136,5 +136,5 @@ func (b *DeleteStmt) Exec() (sql.Result, error) {
 }
 
 func (b *DeleteStmt) ExecContext(ctx context.Context) (sql.Result, error) {
-	return exec(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	return exec(ctx, b.Runner, b.EventReceiver, b, b.Dialect)
 }

--- a/insert.go
+++ b/insert.go
@@ -11,7 +11,7 @@ import (
 
 // InsertStmt builds `INSERT INTO ...`.
 type InsertStmt struct {
-	runner
+	Runner
 	EventReceiver
 	Dialect
 
@@ -113,7 +113,7 @@ func InsertInto(table string) *InsertStmt {
 // InsertInto creates an InsertStmt.
 func (sess *Session) InsertInto(table string) *InsertStmt {
 	b := InsertInto(table)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -122,7 +122,7 @@ func (sess *Session) InsertInto(table string) *InsertStmt {
 // InsertInto creates an InsertStmt.
 func (tx *Tx) InsertInto(table string) *InsertStmt {
 	b := InsertInto(table)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -141,7 +141,7 @@ func InsertBySql(query string, value ...interface{}) *InsertStmt {
 // InsertBySql creates an InsertStmt from raw query.
 func (sess *Session) InsertBySql(query string, value ...interface{}) *InsertStmt {
 	b := InsertBySql(query, value...)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -150,7 +150,7 @@ func (sess *Session) InsertBySql(query string, value ...interface{}) *InsertStmt
 // InsertBySql creates an InsertStmt from raw query.
 func (tx *Tx) InsertBySql(query string, value ...interface{}) *InsertStmt {
 	b := InsertBySql(query, value...)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -239,7 +239,7 @@ func (b *InsertStmt) Exec() (sql.Result, error) {
 }
 
 func (b *InsertStmt) ExecContext(ctx context.Context) (sql.Result, error) {
-	result, err := exec(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	result, err := exec(ctx, b.Runner, b.EventReceiver, b, b.Dialect)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func (b *InsertStmt) ExecContext(ctx context.Context) (sql.Result, error) {
 }
 
 func (b *InsertStmt) LoadContext(ctx context.Context, value interface{}) error {
-	_, err := query(ctx, b.runner, b.EventReceiver, b, b.Dialect, value)
+	_, err := query(ctx, b.Runner, b.EventReceiver, b, b.Dialect, value)
 	return err
 }
 

--- a/select.go
+++ b/select.go
@@ -10,7 +10,7 @@ import (
 
 // SelectStmt builds `SELECT ...`.
 type SelectStmt struct {
-	runner
+	Runner
 	EventReceiver
 	Dialect
 
@@ -225,7 +225,7 @@ func prepareSelect(a []string) []interface{} {
 // Select creates a SelectStmt.
 func (sess *Session) Select(column ...string) *SelectStmt {
 	b := Select(prepareSelect(column)...)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -234,7 +234,7 @@ func (sess *Session) Select(column ...string) *SelectStmt {
 // Select creates a SelectStmt.
 func (tx *Tx) Select(column ...string) *SelectStmt {
 	b := Select(prepareSelect(column)...)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -255,7 +255,7 @@ func SelectBySql(query string, value ...interface{}) *SelectStmt {
 // SelectBySql creates a SelectStmt from raw query.
 func (sess *Session) SelectBySql(query string, value ...interface{}) *SelectStmt {
 	b := SelectBySql(query, value...)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -264,7 +264,7 @@ func (sess *Session) SelectBySql(query string, value ...interface{}) *SelectStmt
 // SelectBySql creates a SelectStmt from raw query.
 func (tx *Tx) SelectBySql(query string, value ...interface{}) *SelectStmt {
 	b := SelectBySql(query, value...)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -407,12 +407,12 @@ func (b *SelectStmt) Rows() (*sql.Rows, error) {
 }
 
 func (b *SelectStmt) RowsContext(ctx context.Context) (*sql.Rows, error) {
-	_, rows, err := queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	_, rows, err := queryRows(ctx, b.Runner, b.EventReceiver, b, b.Dialect)
 	return rows, err
 }
 
 func (b *SelectStmt) LoadOneContext(ctx context.Context, value interface{}) error {
-	count, err := query(ctx, b.runner, b.EventReceiver, b, b.Dialect, value)
+	count, err := query(ctx, b.Runner, b.EventReceiver, b, b.Dialect, value)
 	if err != nil {
 		return err
 	}
@@ -431,7 +431,7 @@ func (b *SelectStmt) LoadOne(value interface{}) error {
 }
 
 func (b *SelectStmt) LoadContext(ctx context.Context, value interface{}) (int, error) {
-	return query(ctx, b.runner, b.EventReceiver, b, b.Dialect, value)
+	return query(ctx, b.Runner, b.EventReceiver, b, b.Dialect, value)
 }
 
 // Load loads multi-row SQL result into a slice of go variables.
@@ -448,7 +448,7 @@ func (b *SelectStmt) Iterate() (Iterator, error) {
 
 // IterateContext executes the query and returns the Iterator, or any error encountered.
 func (b *SelectStmt) IterateContext(ctx context.Context) (Iterator, error) {
-	_, rows, err := queryRows(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	_, rows, err := queryRows(ctx, b.Runner, b.EventReceiver, b, b.Dialect)
 	if err != nil {
 		if rows != nil {
 			rows.Close()

--- a/update.go
+++ b/update.go
@@ -8,7 +8,7 @@ import (
 
 // UpdateStmt builds `UPDATE ...`.
 type UpdateStmt struct {
-	runner
+	Runner
 	EventReceiver
 	Dialect
 
@@ -105,7 +105,7 @@ func Update(table string) *UpdateStmt {
 // Update creates an UpdateStmt.
 func (sess *Session) Update(table string) *UpdateStmt {
 	b := Update(table)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -114,7 +114,7 @@ func (sess *Session) Update(table string) *UpdateStmt {
 // Update creates an UpdateStmt.
 func (tx *Tx) Update(table string) *UpdateStmt {
 	b := Update(table)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -135,7 +135,7 @@ func UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 // UpdateBySql creates an UpdateStmt with raw query.
 func (sess *Session) UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 	b := UpdateBySql(query, value...)
-	b.runner = sess
+	b.Runner = sess
 	b.EventReceiver = sess.EventReceiver
 	b.Dialect = sess.Dialect
 	return b
@@ -144,7 +144,7 @@ func (sess *Session) UpdateBySql(query string, value ...interface{}) *UpdateStmt
 // UpdateBySql creates an UpdateStmt with raw query.
 func (tx *Tx) UpdateBySql(query string, value ...interface{}) *UpdateStmt {
 	b := UpdateBySql(query, value...)
-	b.runner = tx
+	b.Runner = tx
 	b.EventReceiver = tx.EventReceiver
 	b.Dialect = tx.Dialect
 	return b
@@ -209,11 +209,11 @@ func (b *UpdateStmt) Exec() (sql.Result, error) {
 }
 
 func (b *UpdateStmt) ExecContext(ctx context.Context) (sql.Result, error) {
-	return exec(ctx, b.runner, b.EventReceiver, b, b.Dialect)
+	return exec(ctx, b.Runner, b.EventReceiver, b, b.Dialect)
 }
 
 func (b *UpdateStmt) LoadContext(ctx context.Context, value interface{}) error {
-	_, err := query(ctx, b.runner, b.EventReceiver, b, b.Dialect, value)
+	_, err := query(ctx, b.Runner, b.EventReceiver, b, b.Dialect, value)
 	return err
 }
 


### PR DESCRIPTION
Making this public will allow us to write an adapter to use dbr to run queries through our existing SQL driver stack (logging, rate limiting, etc)