### PR TITLE
Run tests as subtests with names

### DIFF
--- a/comments_test.go
+++ b/comments_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/gocraft/dbr/v2/dialect"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,18 +29,8 @@ func TestComments(t *testing.T) {
 			expect:   "/* test nested comment removed */\n",
 		},
 	} {
-
 		for _, sess := range testSession {
-			name := ""
-			switch sess.Dialect {
-			case dialect.MySQL:
-				name = "MySQL"
-			case dialect.PostgreSQL:
-				name = "PostgreSQL"
-			case dialect.SQLite3:
-				name = "SQLite3"
-			}
-			t.Run(fmt.Sprintf("%s/%s", name, test.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("%s/%s", testSessionName(sess), test.name), func(t *testing.T) {
 				buf := NewBuffer()
 				err := test.comments.Build(sess.Dialect, buf)
 				require.NoError(t, err)

--- a/dbr_test.go
+++ b/dbr_test.go
@@ -60,6 +60,20 @@ type nullTypedRecord struct {
 	BoolVal    NullBool
 }
 
+func testSessionName(sess *Session) string {
+	switch sess.Dialect {
+	case dialect.MySQL:
+		return "MySQL"
+	case dialect.PostgreSQL:
+		return "PostgreSQL"
+	case dialect.SQLite3:
+		return "SQLite3"
+	case dialect.MSSQL:
+		return "MSSQL"
+	}
+	return ""
+}
+
 func reset(t *testing.T, sess *Session) {
 	autoIncrementType := "serial PRIMARY KEY"
 	boolType := "bool"
@@ -100,123 +114,120 @@ func reset(t *testing.T, sess *Session) {
 
 func TestBasicCRUD(t *testing.T) {
 	for _, sess := range testSession {
-		reset(t, sess)
+		t.Run(testSessionName(sess), func(t *testing.T) {
+			reset(t, sess)
 
-		jonathan := dbrPerson{
-			Name:  "jonathan",
-			Email: "jonathan@uservoice.com",
-		}
-		insertColumns := []string{"name", "email"}
-		if sess.Dialect == dialect.PostgreSQL {
-			jonathan.Id = 1
-			insertColumns = []string{"id", "name", "email"}
-		}
-		if sess.Dialect == dialect.MSSQL {
-			jonathan.Id = 1
-		}
+			jonathan := dbrPerson{
+				Name:  "jonathan",
+				Email: "jonathan@uservoice.com",
+			}
+			insertColumns := []string{"name", "email"}
+			if sess.Dialect == dialect.PostgreSQL {
+				jonathan.Id = 1
+				insertColumns = []string{"id", "name", "email"}
+			}
+			if sess.Dialect == dialect.MSSQL {
+				jonathan.Id = 1
+			}
 
-		// insert
-		result, err := sess.InsertInto("dbr_people").Columns(insertColumns...).Record(&jonathan).Exec()
-		require.NoError(t, err)
+			// insert
+			result, err := sess.InsertInto("dbr_people").Columns(insertColumns...).Record(&jonathan).Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		require.True(t, jonathan.Id > 0)
-		// select
-		var people []dbrPerson
-		count, err := sess.Select("*").From("dbr_people").Where(Eq("id", jonathan.Id)).Load(&people)
-		require.NoError(t, err)
-		require.Equal(t, 1, count)
-		require.Equal(t, jonathan.Id, people[0].Id)
-		require.Equal(t, jonathan.Name, people[0].Name)
-		require.Equal(t, jonathan.Email, people[0].Email)
+			require.True(t, jonathan.Id > 0)
+			// select
+			var people []dbrPerson
+			count, err := sess.Select("*").From("dbr_people").Where(Eq("id", jonathan.Id)).Load(&people)
+			require.NoError(t, err)
+			require.Equal(t, 1, count)
+			require.Equal(t, jonathan.Id, people[0].Id)
+			require.Equal(t, jonathan.Name, people[0].Name)
+			require.Equal(t, jonathan.Email, people[0].Email)
 
-		// select id
-		ids, err := sess.Select("id").From("dbr_people").ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(ids))
+			// select id
+			ids, err := sess.Select("id").From("dbr_people").ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(ids))
 
-		// select id limit
-		ids, err = sess.Select("id").From("dbr_people").Limit(1).ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 1, len(ids))
+			// select id limit
+			ids, err = sess.Select("id").From("dbr_people").Limit(1).ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 1, len(ids))
 
-		// update
-		result, err = sess.Update("dbr_people").Where(Eq("id", jonathan.Id)).Set("name", "jonathan1").Exec()
-		require.NoError(t, err)
+			// update
+			result, err = sess.Update("dbr_people").Where(Eq("id", jonathan.Id)).Set("name", "jonathan1").Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err = result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err = result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		var n NullInt64
-		sess.Select("count(*)").From("dbr_people").Where("name = ?", "jonathan1").LoadOne(&n)
-		require.Equal(t, int64(1), n.Int64)
+			var n NullInt64
+			sess.Select("count(*)").From("dbr_people").Where("name = ?", "jonathan1").LoadOne(&n)
+			require.Equal(t, int64(1), n.Int64)
 
-		// delete
-		result, err = sess.DeleteFrom("dbr_people").Where(Eq("id", jonathan.Id)).Exec()
-		require.NoError(t, err)
+			// delete
+			result, err = sess.DeleteFrom("dbr_people").Where(Eq("id", jonathan.Id)).Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err = result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err = result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		// select id
-		ids, err = sess.Select("id").From("dbr_people").ReturnInt64s()
-		require.NoError(t, err)
-		require.Equal(t, 0, len(ids))
+			// select id
+			ids, err = sess.Select("id").From("dbr_people").ReturnInt64s()
+			require.NoError(t, err)
+			require.Equal(t, 0, len(ids))
+		})
 	}
 }
 
 func TestTimeout(t *testing.T) {
-	mysqlSession := createSession("mysql", mysqlDSN)
-	postgresSession := createSession("postgres", postgresDSN)
-	sqlite3Session := createSession("sqlite3", sqlite3DSN)
-
-	// all test sessions should be here
-	testSession := []*Session{mysqlSession, postgresSession, sqlite3Session}
-
 	for _, sess := range testSession {
-		reset(t, sess)
+		t.Run(testSessionName(sess), func(t *testing.T) {
+			reset(t, sess)
 
-		// session op timeout
-		sess.Timeout = time.Nanosecond
-		var people []dbrPerson
-		_, err := sess.Select("*").From("dbr_people").Load(&people)
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+			// session op timeout
+			sess.Timeout = time.Nanosecond
+			var people []dbrPerson
+			_, err := sess.Select("*").From("dbr_people").Load(&people)
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		_, err = sess.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = sess.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 2, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		_, err = sess.Update("dbr_people").Set("name", "test1").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = sess.Update("dbr_people").Set("name", "test1").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 3, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		_, err = sess.DeleteFrom("dbr_people").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
-		require.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
+			_, err = sess.DeleteFrom("dbr_people").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+			require.Equal(t, 4, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		// tx op timeout
-		sess.Timeout = 0
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
-		tx.Timeout = time.Nanosecond
+			// tx op timeout
+			sess.Timeout = 0
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
+			tx.Timeout = time.Nanosecond
 
-		_, err = tx.Select("*").From("dbr_people").Load(&people)
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.Select("*").From("dbr_people").Load(&people)
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		_, err = tx.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.InsertInto("dbr_people").Columns("name", "email").Values("test", "test@test.com").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		_, err = tx.Update("dbr_people").Set("name", "test1").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.Update("dbr_people").Set("name", "test1").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
 
-		_, err = tx.DeleteFrom("dbr_people").Exec()
-		require.Equal(t, context.DeadlineExceeded, err)
+			_, err = tx.DeleteFrom("dbr_people").Exec()
+			require.Equal(t, context.DeadlineExceeded, err)
+		})
 	}
 }

--- a/interpolate_test.go
+++ b/interpolate_test.go
@@ -159,21 +159,23 @@ func TestInterpolateForDialect(t *testing.T) {
 // more information on the source and the strings themselves.
 func TestCommonSQLInjections(t *testing.T) {
 	for _, sess := range testSession {
-		reset(t, sess)
+		t.Run(testSessionName(sess), func(t *testing.T) {
+			reset(t, sess)
 
-		for _, injectionAttempt := range strings.Split(injectionAttempts, "\n") {
-			// Create a user with the attempted injection as the email address
-			_, err := sess.InsertInto("dbr_people").
-				Pair("name", injectionAttempt).
-				Exec()
-			require.NoError(t, err)
+			for _, injectionAttempt := range strings.Split(injectionAttempts, "\n") {
+				// Create a user with the attempted injection as the email address
+				_, err := sess.InsertInto("dbr_people").
+					Pair("name", injectionAttempt).
+					Exec()
+				require.NoError(t, err)
 
-			// SELECT the name back and ensure it's equal to the injection attempt
-			var name string
-			err = sess.Select("name").From("dbr_people").OrderDesc("id").Limit(1).LoadOne(&name)
-			require.NoError(t, err)
-			require.Equal(t, injectionAttempt, name)
-		}
+				// SELECT the name back and ensure it's equal to the injection attempt
+				var name string
+				err = sess.Select("name").From("dbr_people").OrderDesc("id").Limit(1).LoadOne(&name)
+				require.NoError(t, err)
+				require.Equal(t, injectionAttempt, name)
+			}
+		})
 	}
 }
 

--- a/transaction_test.go
+++ b/transaction_test.go
@@ -9,69 +9,73 @@ import (
 
 func TestTransactionCommit(t *testing.T) {
 	for _, sess := range testSession {
-		reset(t, sess)
+		t.Run(testSessionName(sess), func(t *testing.T) {
+			reset(t, sess)
 
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
 
-		elem_count := 1
-		if sess.Dialect == dialect.MSSQL {
-			tx.UpdateBySql("SET IDENTITY_INSERT dbr_people ON;").Exec()
-			elem_count += 1
-		}
+			elem_count := 1
+			if sess.Dialect == dialect.MSSQL {
+				tx.UpdateBySql("SET IDENTITY_INSERT dbr_people ON;").Exec()
+				elem_count += 1
+			}
 
-		id := 1
-		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Comment("INSERT TEST").Exec()
-		require.NoError(t, err)
-		require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, elem_count)
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].eventName, "dbr.exec")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "/* INSERT TEST */\n")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "INSERT")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "dbr_people")
-		require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "name")
-		require.Equal(t, elem_count, sess.EventReceiver.(*testTraceReceiver).finished)
-		require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
+			id := 1
+			result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Comment("INSERT TEST").Exec()
+			require.NoError(t, err)
+			require.Len(t, sess.EventReceiver.(*testTraceReceiver).started, elem_count)
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].eventName, "dbr.exec")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "/* INSERT TEST */\n")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "INSERT")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "dbr_people")
+			require.Contains(t, sess.EventReceiver.(*testTraceReceiver).started[elem_count-1].query, "name")
+			require.Equal(t, elem_count, sess.EventReceiver.(*testTraceReceiver).finished)
+			require.Equal(t, 0, sess.EventReceiver.(*testTraceReceiver).errored)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		err = tx.Commit()
-		require.NoError(t, err)
+			err = tx.Commit()
+			require.NoError(t, err)
 
-		var person dbrPerson
-		err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
-		require.Error(t, err)
-		require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+			var person dbrPerson
+			err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
+			require.Error(t, err)
+			require.Equal(t, 1, sess.EventReceiver.(*testTraceReceiver).errored)
+		})
 	}
 }
 
 func TestTransactionRollback(t *testing.T) {
 	for _, sess := range testSession {
-		reset(t, sess)
+		t.Run(testSessionName(sess), func(t *testing.T) {
+			reset(t, sess)
 
-		tx, err := sess.Begin()
-		require.NoError(t, err)
-		defer tx.RollbackUnlessCommitted()
+			tx, err := sess.Begin()
+			require.NoError(t, err)
+			defer tx.RollbackUnlessCommitted()
 
-		if sess.Dialect == dialect.MSSQL {
-			tx.UpdateBySql("SET IDENTITY_INSERT dbr_people ON;").Exec()
-		}
+			if sess.Dialect == dialect.MSSQL {
+				tx.UpdateBySql("SET IDENTITY_INSERT dbr_people ON;").Exec()
+			}
 
-		id := 1
-		result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
-		require.NoError(t, err)
+			id := 1
+			result, err := tx.InsertInto("dbr_people").Columns("id", "name", "email").Values(id, "Barack", "obama@whitehouse.gov").Exec()
+			require.NoError(t, err)
 
-		rowsAffected, err := result.RowsAffected()
-		require.NoError(t, err)
-		require.Equal(t, int64(1), rowsAffected)
+			rowsAffected, err := result.RowsAffected()
+			require.NoError(t, err)
+			require.Equal(t, int64(1), rowsAffected)
 
-		err = tx.Rollback()
-		require.NoError(t, err)
+			err = tx.Rollback()
+			require.NoError(t, err)
 
-		var person dbrPerson
-		err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
-		require.Error(t, err)
+			var person dbrPerson
+			err = tx.Select("*").From("dbr_people").Where(Eq("id", id)).LoadOne(&person)
+			require.Error(t, err)
+		})
 	}
 }


### PR DESCRIPTION
Seems that this was only done for comments_test.go, so I changed all the tests to work in the same way. This way it's easier to detect which dialect is failing in each test.

cc @taylorchu 