### PR TITLE
feat(select): support []Builder type in Where method

### DIFF
--- a/select.go
+++ b/select.go
@@ -275,13 +275,15 @@ func (b *SelectStmt) Distinct() *SelectStmt {
 }
 
 // Where adds a where condition.
-// query can be Builder or string. value is used only if query type is string.
+// query can be Builder or []Builder or string. value is used only if query type is string.
 func (b *SelectStmt) Where(query interface{}, value ...interface{}) *SelectStmt {
 	switch query := query.(type) {
 	case string:
 		b.WhereCond = append(b.WhereCond, Expr(query, value...))
 	case Builder:
 		b.WhereCond = append(b.WhereCond, query)
+	case []Builder:
+		b.WhereCond = append(b.WhereCond, query...)
 	}
 	return b
 }

--- a/select_test.go
+++ b/select_test.go
@@ -34,6 +34,22 @@ func TestSelectStmt(t *testing.T) {
 	require.Equal(t, 3, len(buf.Value()))
 }
 
+func TestWhereSliceBuild(t *testing.T) {
+	buf := NewBuffer()
+	builder := Select("a", "b").
+		From("table").
+		Where(
+			[]Builder{
+				Eq("c", 1),
+				Eq("d", 2),
+			},
+		)
+	err := builder.Build(dialect.MySQL, buf)
+	require.NoError(t, err)
+	require.Equal(t, "SELECT a, b FROM table WHERE (`c` = ?) AND (`d` = ?)", buf.String())
+
+}
+
 func BenchmarkSelectSQL(b *testing.B) {
 	buf := NewBuffer()
 	for i := 0; i < b.N; i++ {


### PR DESCRIPTION
Extend the Where method in SelectStmt to accept a slice of Builder instances, allowing for multiple where conditions to be added conveniently in a single call.